### PR TITLE
Abstract return status code steps

### DIFF
--- a/features/basic.feature
+++ b/features/basic.feature
@@ -13,7 +13,7 @@ Feature: Basic Test Execution
         Scenario: Run a test that should pass
             Given that I have a `Gherkin feature that should pass` file located at `./features`
             When I input the command `npx [appname] test`
-            Then the command should return a status of `0`
+            Then the command should return a `success` status code
             And I should see `passing test result` console output
 
     Rule: The run should fail if any tests fail
@@ -21,33 +21,33 @@ Feature: Basic Test Execution
         Scenario: Run a test that should fail
             Given that I have a `Gherkin feature that should fail` file located at `./features`
             When I input the command `npx [appname] test`
-            Then the command should return a status of `1`
+            Then the command should return a `failure` status code
             And I should see `failing test result` console output
 
         Scenario: Run multiple tests that should fail
             Given that I have a `Gherkin feature that should pass` file located at `./features`
             And that I have a `Gherkin feature that should fail` file located at `./features`
             When I input the command `npx [appname] test`
-            Then the command should return a status of `1`
+            Then the command should return a `failure` status code
 
     Rule: Execution without a subcommand should default to testing
 
         Scenario: Run a test with no subcommand
             Given that I have a `Gherkin feature that should pass` file located at `./features`
             When I input the command `npx [appname]`
-            Then the command should return a status of `0`
+            Then the command should return a `success` status code
 
         Scenario: Run a test with no subcommand and additional arguments
             Given that I have a `Gherkin feature that should pass` file located at `./features`
             When I input the command `npx [appname] additional arguments`
-            Then the command should return a status of `0`
+            Then the command should return a `success` status code
 
     Rule: The run should fail if there are no test specs
 
         Scenario: Run a test with no gherkin files in the default location
             Given that the file location ./features is empty
             When I input the command `npx [appname] test`
-            Then the command should return a status of `1`
+            Then the command should return a `failure` status code
             And I should see `no features error` console output
 
     Rule: Users can override the feature file path
@@ -55,12 +55,12 @@ Feature: Basic Test Execution
         Scenario: Run a test with a gherkin file in a custom location
             Given that I have a `Gherkin feature that should pass` file located at `./custom`
             When I input the command `npx [appname] test ./custom`
-            Then the command should return a status of `0`
+            Then the command should return a `success` status code
 
         Scenario: Run a test with no gherkin files in a custom location
             Given that the file location ./custom is empty
             When I input the command `npx [appname] test ./custom`
-            Then the command should return a status of `1`
+            Then the command should return a `failure` status code
             And I should see `no features error` console output
 
     Rule: Users can run subsets of tests using file path and tags
@@ -69,10 +69,10 @@ Feature: Basic Test Execution
             Given that I have a `Gherkin feature that should pass` file located at `./features/pass`
             And that I have a `Gherkin feature that should fail` file located at `./features/fail`
             When I input the command `npx [appname] test ./features/pass`
-            Then the command should return a status of `0`
+            Then the command should return a `success` status code
 
         Scenario: Run a subset of tests based tags
             Given that I have a `Gherkin feature with tags` file located at `./features`
             When I input the command `npx [appname] test --tags "@pass"`
-            Then the command should return a status of `0`
+            Then the command should return a `success` status code
 

--- a/features/retry.feature
+++ b/features/retry.feature
@@ -13,12 +13,12 @@ Feature: Retry Flaky Tests
         Scenario: Run a test that should fail with 2 retries
             Given that I have a `Gherkin feature that should pass on the 3rd retry` file located at `./features`
             When I input the command `npx [appname] test --retry 2`
-            Then the command should return a status of `1`
+            Then the command should return a `failure` status code
 
         Scenario: Run a test that should pass with 3 retries
             Given that I have a `Gherkin feature that should pass on the 3rd retry` file located at `./features`
             When I input the command `npx [appname] test --retry 3`
-            Then the command should return a status of `0`
+            Then the command should return a `success` status code
 
     Rule: Tags can be used to retry only certain tests
 
@@ -26,6 +26,6 @@ Feature: Retry Flaky Tests
             Given that I have a `Gherkin feature that should pass on the 3rd retry` file located at `./features`
             And that I have a `Gherkin feature that fails after 5 seconds` file located at `./features`
             When I input the command `npx [appname] test --retry 3 --retry-tag "@retry"`
-            Then the command shoult return a status of `1`
+            Then the command should return a `failure` status code
             And the elapsed time should be less than `10s`
 


### PR DESCRIPTION
Revised existing scenarios to use a phrasing for the return status check step that abstracts the status code integer into its semantic meaning