### PR TITLE
Browser test mode

### DIFF
--- a/features/browser-mode.feature
+++ b/features/browser-mode.feature
@@ -7,6 +7,7 @@ Feature: Browser Testing Mode
         Given that the `[appname] core test runner` NPM package is installed
         And that the `[appname] browser testing library` NPM package is installed
         And that the `[appname] command line testing library` NPM package is installed
+        And that I have a command line prompt
         And that I have a `Gherkin browser test feature` file located at `./features`
 
     Rule: Tests executed in grid mode run remotely


### PR DESCRIPTION
Added a browser test mode feature file

Note: Initially I thought I would need to refactor these tests as browser tests, but I was mixing up my tests.  It might be that you guys were too, so I thought I should share.  We are writing behavior specifications for the **command line tool** we are building, and so the specs will necessarily describe **command line behaviors** we expect.  The browser testing I briefly thought was missing will actually be encapsulated in the Gherkin test file that the steps say we must have.  So essentially, this is a command line test executing a browser test in order to validate that different modes work as expected.  This is a challenge to keep straight in my head and we'll all need to keep each other on track here.