### PR TITLE
[#92] Specify Watcher

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -95,15 +95,14 @@ export default tseslint.config(
     },
     {
         "ignores": [
-            "./logs/**",
             "**/*.d.ts",
             "**/.DS_Store/**",
             "**/.vscode/**",
+            "**/logs/**",
             "**/node_modules/**",
             "**/dist/**",
             "**/package.json",
             "**/package-lock.json",
-            "logs/",
         ],
     },
 );

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -95,6 +95,7 @@ export default tseslint.config(
     },
     {
         "ignores": [
+            "./logs/**",
             "**/*.d.ts",
             "**/.DS_Store/**",
             "**/.vscode/**",

--- a/features/test/basic.feature
+++ b/features/test/basic.feature
@@ -73,7 +73,7 @@ Feature: Basic Test Execution
         Scenario: Only run tests with the specified tag
             When a user runs the command "npx specify test --tags '@pass' ./assets/gherkin/binary/"
             Then the command should exit with a "success" status code
-        
+
         Scenario: Do not run tests with the specified inverted tag
             When a user runs the command "npx specify test --tags 'not @fail' ./assets/gherkin/binary/"
             Then the command should exit with a "success" status code

--- a/features/test/specify-watch.feature
+++ b/features/test/specify-watch.feature
@@ -1,0 +1,133 @@
+Feature: Watch Mode
+    As a software developer
+    I want to run tests in watch mode that automatically rerun when files change
+    So that I can get immediate feedback during development without manually rerunning tests
+    ssssssss
+    Background:
+        Given that the "@specify/core" NPM package is installed
+        And that the "@specify/plugin-cli" NPM package is installed
+        And that a command line prompt is available
+
+    Rule: Watch mode monitors file changes and reruns tests automatically
+
+        @skip
+        Scenario: Watch mode starts and monitors for changes
+            Given that a "passing feature" file exists at "./features"
+            When a user runs the command "npx specify test --watch"
+            Then the command should start in watch mode
+            And the console output should include "Watching for file changes"
+            And the initial test run should complete with a "success" status code
+
+        @skip
+        Scenario: Test reruns automatically when feature file changes
+            Given that a "passing feature" file exists at "./features"
+            And that watch mode is running
+            When the feature file is modified
+            Then the tests should automatically rerun
+
+        @skip
+        Scenario: Test reruns automatically when step definition changes
+            Given that a "passing feature" file exists at "./features"
+            And that a custom step definition file exists at "./features/steps"
+            And that watch mode is running
+            When the step definition file is modified
+            Then the tests should automatically rerun
+
+        @skip
+        Scenario: Watch mode reruns only affected tests when using specific file paths
+            Given that a "passing feature" file exists at "./features/test1.feature"
+            And that a "passing feature" file exists at "./features/test2.feature"
+            And that watch mode is running with "npx specify test --watch ./features/test1.feature"
+            When "./features/test2.feature" is modified
+            Then the tests should not rerun
+            When "./features/test1.feature" is modified
+            Then the tests should automatically rerun
+
+    Rule: Watch mode can be combined with other options
+
+        @skip
+        Scenario: Watch mode with retry option
+            Given that a "flaky feature" file exists at "./features"
+            When a user runs the command "npx specify test --watch --retry 2"
+            Then the command should start in watch mode
+            And failed tests should be retried according to the retry setting
+
+        @skip
+        Scenario: Watch mode with parallel execution
+            Given that multiple "passing feature" files exist at "./features"
+            When a user runs the command "npx specify test --watch --parallel 2"
+            Then the command should start in watch mode
+            And tests should run in parallel according to the parallel setting
+
+        @skip
+        Scenario: Watch mode with tag filtering
+            Given that a "tagged feature" file exists at "./features"
+            When a user runs the command "npx specify test --watch --tags '@smoke'"
+            Then the command should start in watch mode
+            And only tests matching the tag filter should run
+
+    Rule: Watch mode handles file system events appropriately
+
+        @skip
+        Scenario: Watch mode ignores temporary files
+            Given that a "passing feature" file exists at "./features"
+            And that watch mode is running
+            When a temporary file is created in "./features"
+            Then the tests should not rerun
+
+        @skip
+        Scenario: Watch mode handles file deletion gracefully
+            Given that a "passing feature" file exists at "./features/deleteme.feature"
+            And that watch mode is running
+            When "./features/deleteme.feature" is deleted
+            Then the tests should automatically rerun
+
+        @skip
+        Scenario: Watch mode handles new file creation
+            Given that watch mode is running for "./features"
+            When a new feature file is created at "./features/newtest.feature"
+            Then the tests should automatically rerun
+            And the new test should be included in the test run
+
+    Rule: Watch mode can be stopped gracefully
+
+        @skip
+        Scenario: Watch mode stops on user interrupt
+            Given that watch mode is running
+            When the user sends a SIGINT signal (Ctrl+C)
+            Then the watch mode should stop gracefully
+            And the console output should include "Watch mode stopped"
+
+        @skip
+        Scenario: Watch mode exits with error status when interrupted during test run
+            Given that a "long running feature" file exists at "./features"
+            And that watch mode is running
+            When the user sends a SIGINT signal during test execution
+            Then the watch mode should stop gracefully
+            And the command should exit with an appropriate status code
+
+    Rule: Watch mode provides clear status information
+
+        @skip
+        Scenario: Watch mode shows file change detection and test completion status
+            Given that watch mode is running
+            When a monitored file changes
+            Then the console output should include the name of the changed file
+            And the console output should include a timestamp of the change
+            When tests complete after the file change
+            Then the console output should include the test results summary
+            And the console output should include "Waiting for file changes..."
+
+    Rule: Watch mode option validation
+
+        @skip
+        Scenario: Watch mode conflicts with rerun option
+            When a user runs the command "npx specify test --watch --rerun"
+            Then the command should exit with an "error" status code
+            And the console output should include "conflicting options"
+
+        @skip
+        Scenario: Watch mode requires valid file paths
+            When a user runs the command "npx specify test --watch ./nonexistent/path"
+            Then the command should exit with an "error" status code
+            And the console output should include "path not found error"

--- a/features/test/specify-watch.feature
+++ b/features/test/specify-watch.feature
@@ -2,7 +2,7 @@ Feature: Watch Mode
     As a software developer
     I want to run tests in watch mode that automatically rerun when files change
     So that I can get immediate feedback during development without manually rerunning tests
-    ssssssss
+
     Background:
         Given that the "@specify/core" NPM package is installed
         And that the "@specify/plugin-cli" NPM package is installed

--- a/features/test/specify-watch.feature
+++ b/features/test/specify-watch.feature
@@ -1,3 +1,4 @@
+@manual
 Feature: Watch Mode
     As a software developer
     I want to run tests in watch mode that automatically rerun when files change
@@ -31,16 +32,6 @@ Feature: Watch Mode
             And that a custom step definition file exists at "./features/steps"
             And that watch mode is running
             When the step definition file is modified
-            Then the tests should automatically rerun
-
-        @skip
-        Scenario: Watch mode reruns only affected tests when using specific file paths
-            Given that a "passing feature" file exists at "./features/test1.feature"
-            And that a "passing feature" file exists at "./features/test2.feature"
-            And that watch mode is running with "npx specify test --watch ./features/test1.feature"
-            When "./features/test2.feature" is modified
-            Then the tests should not rerun
-            When "./features/test1.feature" is modified
             Then the tests should automatically rerun
 
     Rule: Watch mode can be combined with other options
@@ -105,18 +96,6 @@ Feature: Watch Mode
             When the user sends a SIGINT signal during test execution
             Then the watch mode should stop gracefully
             And the command should exit with an appropriate status code
-
-    Rule: Watch mode provides clear status information
-
-        @skip
-        Scenario: Watch mode shows file change detection and test completion status
-            Given that watch mode is running
-            When a monitored file changes
-            Then the console output should include the name of the changed file
-            And the console output should include a timestamp of the change
-            When tests complete after the file change
-            Then the console output should include the test results summary
-            And the console output should include "Waiting for file changes..."
 
     Rule: Watch mode option validation
 

--- a/modules/@specify/core/bin/specify.js
+++ b/modules/@specify/core/bin/specify.js
@@ -6,7 +6,20 @@ import process from "node:process";
 import { error } from "node:console";
 
 import("../dist/main.js").catch((err) => {
-    error("Executable hasn't been built yet:", err.message);
+    switch (err.code) {
+        case "ERR_MODULE_NOT_FOUND":
+            error(
+                "Module not found. Have you built the project? Run `npm run build`.",
+            );
+            break;
+        case "ERR_REQUIRE_ESM":
+            error(
+                "This module requires ESM support. Please ensure your Node.js version supports ESM.",
+            );
+            break;
+        default:
+            error("An unexpected error occurred:", err);
+    }
 
     process.exit(1);
 });

--- a/modules/@specify/core/bin/specify.js
+++ b/modules/@specify/core/bin/specify.js
@@ -8,9 +8,7 @@ import { error } from "node:console";
 import("../dist/main.js").catch((err) => {
     switch (err.code) {
         case "ERR_MODULE_NOT_FOUND":
-            error(
-                "Module not found. Have you built the project? Run `npm run build`.",
-            );
+            error("Module not found. Have you built the project? Run `npm run build`.");
             break;
         case "ERR_REQUIRE_ESM":
             error(
@@ -21,5 +19,5 @@ import("../dist/main.js").catch((err) => {
             error("An unexpected error occurred:", err);
     }
 
-    process.exit(1);
+    process.exit(2);
 });

--- a/modules/@specify/core/package.json
+++ b/modules/@specify/core/package.json
@@ -25,6 +25,8 @@
   "dependencies": {
     "@cucumber/cucumber": "^11.3.0",
     "@specify/quick-ref": "workspace:*",
+    "chalk": "^5.4.1",
+    "chokidar": "^4.0.3",
     "globby": "^14.1.0",
     "minimist": "^1.2.8",
     "serialize-error": "^12.0.0",

--- a/modules/@specify/core/package.json
+++ b/modules/@specify/core/package.json
@@ -27,18 +27,18 @@
     "@specify/quick-ref": "workspace:*",
     "chalk": "^5.4.1",
     "chokidar": "^4.0.3",
+    "deepmerge": "^4.3.1",
     "globby": "^14.1.0",
     "lodash": "^4.17.21",
     "minimist": "^1.2.8",
-    "serialize-error": "^12.0.0",
-    "type-fest": "^4.41.0"
+    "serialize-error": "^12.0.0"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.5",
     "@types/resolve": "^1.20.6",
-    "deepmerge": "^4.3.1",
     "ts-morph": "^25.0.1",
     "tsc-alias": "^1.8.16",
+    "type-fest": "^4.41.0",
     "typescript": "^5.8.3"
   },
   "engines": {

--- a/modules/@specify/core/package.json
+++ b/modules/@specify/core/package.json
@@ -28,6 +28,7 @@
     "chalk": "^5.4.1",
     "chokidar": "^4.0.3",
     "globby": "^14.1.0",
+    "lodash": "^4.17.21",
     "minimist": "^1.2.8",
     "serialize-error": "^12.0.0",
     "type-fest": "^4.41.0"

--- a/modules/@specify/core/src/config/paths.config.ts
+++ b/modules/@specify/core/src/config/paths.config.ts
@@ -4,22 +4,10 @@
  * @example "\\.test\\.ts$" or "node_modules"
  */
 
-// more descriptive type names
-type DirectoryString = string;
-type RegExpString = string;
-
-type WatchPathsConfig = {
-    paths: DirectoryString[];
-    ignore: RegExpString[];
-};
-
 export type PathsConfig = {
-    [key: string]: string | WatchPathsConfig | undefined;
-
     gherkin: string;
     logs: string;
     refs: string;
-    watch?: WatchPathsConfig;
 };
 
 export const paths: PathsConfig = {

--- a/modules/@specify/core/src/config/paths.config.ts
+++ b/modules/@specify/core/src/config/paths.config.ts
@@ -1,4 +1,26 @@
-export type PathsConfig = Record<string, string>;
+/**
+ * A string that will be converted to a RegExp pattern
+ *
+ * @example "\\.test\\.ts$" or "node_modules"
+ */
+
+// more descriptive type names
+type DirectoryString = string;
+type RegExpString = string;
+
+type WatchPathsConfig = {
+    paths: DirectoryString[];
+    ignore: RegExpString[];
+};
+
+export type PathsConfig = {
+    [key: string]: string | WatchPathsConfig | undefined;
+
+    gherkin: string;
+    logs: string;
+    refs: string;
+    watch?: WatchPathsConfig;
+};
 
 export const paths: PathsConfig = {
     "gherkin": "./features/**/*.feature",

--- a/modules/@specify/core/src/config/paths.config.ts
+++ b/modules/@specify/core/src/config/paths.config.ts
@@ -1,10 +1,5 @@
-/**
- * A string that will be converted to a RegExp pattern
- *
- * @example "\\.test\\.ts$" or "node_modules"
- */
-
 export type PathsConfig = {
+    [key: string]: string;
     gherkin: string;
     logs: string;
     refs: string;

--- a/modules/@specify/core/src/config/watch.config.ts
+++ b/modules/@specify/core/src/config/watch.config.ts
@@ -1,0 +1,40 @@
+/**
+ * A string that will be converted to a RegExp pattern.
+ *
+ * @example "\\.test\\.ts$" or "node_modules"
+ */
+type RegExpString = string;
+
+/**
+ * A string representing a directory path to watch.
+ *
+ * @example "./features" or "./modules/\@specify/core/dist"
+ */
+type DirectoryString = string;
+
+/**
+ * File system events that can be watched by chokidar.
+ */
+type WatchEventString = "add" | "change" | "unlink" | "addDir" | "unlinkDir";
+
+export type WatchConfig = {
+    debug?: boolean;
+    paths: DirectoryString[];
+    ignore: RegExpString[];
+    events?: WatchEventString[];
+};
+
+export const watch: WatchConfig = {
+    "debug":  false,
+    "paths":  ["./"],
+    "ignore": [
+        "\\.test\\.ts$",
+        "\\.spec\\.ts$",
+        "__tests__",
+        "__mocks__",
+        "\\.d\\.ts$",
+        "\\/node_modules\\/",
+        "\\.git",
+    ],
+    "events": ["add", "change", "unlink"],
+};

--- a/modules/@specify/core/src/lib/Command.ts
+++ b/modules/@specify/core/src/lib/Command.ts
@@ -63,11 +63,7 @@ export abstract class Command {
      * @param userOpts - User-supplied options
      */
     constructor(userOpts: ICommandOptions) {
-        const mergedOpts = merge.all([
-            {},
-            COMMAND_DEFAULT_OPTS,
-            userOpts,
-        ]) as ICommandOptions;
+        const mergedOpts = merge.all([{}, COMMAND_DEFAULT_OPTS, userOpts]) as ICommandOptions;
 
         this.debug = mergedOpts.debug;
         this.logPath = mergedOpts.logPath;
@@ -85,9 +81,7 @@ export abstract class Command {
         const res: ICommandResult = {
             "ok":     false,
             "status": CommandResultStatus.error,
-            "error":  serializeError(
-                new Error("Base class Command should not be executed."),
-            ),
+            "error":  serializeError(new Error("Base class Command should not be executed.")),
         };
 
         if (this.debug) {

--- a/modules/@specify/core/src/lib/Command.ts
+++ b/modules/@specify/core/src/lib/Command.ts
@@ -16,9 +16,11 @@ export const COMMAND_DEFAULT_OPTS: ICommandOptions = {
     "logPath": `./specify-log-${Date.now()}.json`,
 };
 
+export const SPECIFY_ARGS = ["help", "watch"];
+
 export interface ICommandOptions {
-    debug: boolean;
-    logPath: string;
+    debug?: boolean;
+    logPath?: string;
 }
 
 export interface ICommandResult {
@@ -31,6 +33,10 @@ export interface ICommandResult {
 
 export interface ICommandResultDebugInfo {
     args: ParsedArgs;
+}
+
+export interface ISpecifyArgs {
+    watch?: boolean;
 }
 
 export enum CommandResultStatus {
@@ -55,8 +61,12 @@ export abstract class Command {
      *
      * @param userOpts - User-supplied options
      */
-    constructor(userOpts: Partial<ICommandOptions>) {
-        const mergedOpts = merge.all([{}, COMMAND_DEFAULT_OPTS, userOpts]) as ICommandOptions;
+    constructor(userOpts: ICommandOptions) {
+        const mergedOpts = merge.all([
+            {},
+            COMMAND_DEFAULT_OPTS,
+            userOpts,
+        ]) as ICommandOptions;
 
         this.debug = mergedOpts.debug;
         this.logPath = mergedOpts.logPath;
@@ -74,7 +84,9 @@ export abstract class Command {
         const res: ICommandResult = {
             "ok":     false,
             "status": CommandResultStatus.error,
-            "error":  serializeError(new Error("Base class Command should not be executed.")),
+            "error":  serializeError(
+                new Error("Base class Command should not be executed."),
+            ),
         };
 
         if (this.debug) {

--- a/modules/@specify/core/src/lib/Command.ts
+++ b/modules/@specify/core/src/lib/Command.ts
@@ -36,6 +36,7 @@ export interface ICommandResultDebugInfo {
 }
 
 export interface ISpecifyArgs {
+    help?: boolean;
     watch?: boolean;
 }
 

--- a/modules/@specify/core/src/lib/TestCommandWatcher.test.ts
+++ b/modules/@specify/core/src/lib/TestCommandWatcher.test.ts
@@ -6,6 +6,13 @@ import { watch } from "chokidar";
 import { DEBOUNCE_MS, TestCommandWatcher } from "./TestCommandWatcher";
 import { TestCommand                     } from "./TestCommand";
 
+// mock TestCommand class completely
+vi.mock("./TestCommand", () => ({
+    "TestCommand": vi.fn().mockImplementation(() => ({
+        "execute": vi.fn().mockResolvedValue({ "ok": true, "status": 0 }),
+    })),
+}));
+
 // test constants
 const MOCK_ARGS        = { "_": [] };
 const LOCK_FILE_NAME   = "specify-core-watch.lock";
@@ -99,9 +106,8 @@ describe("TestCommandWatcher", () => {
 
         mockMkdtempSync.mockReturnValue(path.join(os.tmpdir(), "specify-test-mocked"));
 
+        // create mock command instance using the mocked constructor
         mockCommand = new TestCommand(config);
-
-        vi.spyOn(mockCommand, "execute").mockResolvedValue({ "ok": true, "status": 0 });
 
         mockWatcherInstance = {
             "on": vi.fn().mockReturnThis(),

--- a/modules/@specify/core/src/lib/TestCommandWatcher.test.ts
+++ b/modules/@specify/core/src/lib/TestCommandWatcher.test.ts
@@ -1,0 +1,310 @@
+import fs        from "node:fs";
+import path      from "node:path";
+import { watch } from "chokidar";
+
+import { DEBOUNCE_MS, TestCommandWatcher } from "./TestCommandWatcher";
+
+import type { TestCommand } from "./TestCommand";
+
+// test constants
+const MOCK_ARGS        = { "_": [] };
+const LOCK_FILE_NAME   = "specify-core-watch.lock";
+const TEST_FILE_PATH   = "/some/file.ts";
+const CONFIG_FILE_NAME = "specify.config.json";
+
+// helper functions
+const mockDebouncedExecution = () =>
+    new Promise((resolve) => setTimeout(resolve, DEBOUNCE_MS + 100));
+
+const createMockConfig = (paths: string[] = ["./src", "./features"]) => ({
+    "config": {
+        "debug": false,
+        "watch": {
+            "debug":  false,
+            "events": ["add", "change", "unlink"],
+            "ignore": ["node_modules", ".git"],
+
+            paths,
+        },
+    },
+});
+
+// mocks
+const mockWatch         = vi.mocked(watch);
+const mockFs            = vi.mocked(fs);
+const mockExistsSync    = vi.fn();
+const mockWriteFileSync = vi.fn();
+const mockUnlinkSync    = vi.fn();
+const mockWatchFs       = vi.fn();
+
+mockFs.existsSync = mockExistsSync;
+mockFs.writeFileSync = mockWriteFileSync;
+mockFs.unlinkSync = mockUnlinkSync;
+mockFs.watch = mockWatchFs;
+
+vi.mock("chokidar");
+vi.mock("node:fs");
+vi.mock("node:console", () => ({
+    "clear": vi.fn(),
+    "log":   vi.fn(),
+}));
+vi.mock("@/config/all", () => ({
+    "config": {
+        "debug": false,
+        "watch": {
+            "debug":  false,
+            "events": ["add", "change", "unlink"],
+            "ignore": ["node_modules", ".git"],
+            "paths":  ["./src", "./features"],
+        },
+    },
+}));
+
+describe("TestCommandWatcher", () => {
+    let mockCommand: TestCommand;
+    let watcher: TestCommandWatcher;
+    let mockWatcherInstance: { on: ReturnType<typeof vi.fn> };
+
+    // helper functions for tests
+    const getFileChangeHandler = () => {
+        const calls   = mockWatcherInstance.on.mock.calls;
+        const allCall = calls.find((call: [string, unknown]) => call[0] === "all");
+        return allCall?.[1] as (event: string, filePath: string) => Promise<void>;
+    };
+
+    const expectLockFile      = () => expect.stringContaining(LOCK_FILE_NAME);
+    const setupMockExistsSync = (value: boolean) => mockExistsSync.mockReturnValue(value);
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        mockCommand = {
+            "execute": vi.fn().mockResolvedValue({ "ok": true, "status": 0 }),
+        } as unknown as TestCommand;
+
+        mockWatcherInstance = {
+            "on": vi.fn().mockReturnThis(),
+        };
+
+        mockWatch.mockReturnValue(mockWatcherInstance as unknown as ReturnType<typeof watch>);
+
+        watcher = new TestCommandWatcher(mockCommand);
+    });
+
+    describe("constructor()", () => {
+        it("initializes with TestCommand instance", () => {
+            expect(watcher).toBeInstanceOf(TestCommandWatcher);
+        });
+    });
+
+    describe("start()", () => {
+        beforeEach(() => {
+            setupMockExistsSync(false);
+
+            vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+        });
+
+        afterEach(() => {
+            vi.mocked(process.exit).mockRestore();
+        });
+
+        it("clears console and starts watching configured paths", async () => {
+            const { clear } = await import("node:console");
+
+            await watcher.start(MOCK_ARGS);
+
+            expect(clear).toHaveBeenCalled();
+            expect(mockWatch).toHaveBeenCalledWith(
+                [path.resolve("./src"), path.resolve("./features")],
+                expect.objectContaining({
+                    "ignored":    expect.any(Array),
+                    "persistent": true,
+                }),
+            );
+        });
+
+        it("exits with error when no watch paths configured", async () => {
+            // modify the existing mock; clear the watch paths
+            vi.doMock("@/config/all", () => createMockConfig([]));
+
+            // clear modules to force reimport with new mock
+            vi.resetModules();
+
+            const { "TestCommandWatcher": emptyPathWatcher } = await import("./TestCommandWatcher");
+
+            const emptyWatcher = new emptyPathWatcher(mockCommand);
+
+            await emptyWatcher.start(MOCK_ARGS);
+
+            expect(process.exit).toHaveBeenCalledWith(1);
+        });
+
+        it("removes existing lock file on start", async () => {
+            mockExistsSync.mockReturnValue(true);
+
+            await watcher.start(MOCK_ARGS);
+
+            expect(mockUnlinkSync).toHaveBeenCalledWith(expectLockFile());
+        });
+
+        it("sets up file system watcher with correct event handler", async () => {
+            await watcher.start(MOCK_ARGS);
+
+            expect(mockWatcherInstance.on).toHaveBeenCalledWith("all", expect.any(Function));
+        });
+    });
+
+    describe("file change handling", () => {
+        let changeHandler: (event: string, filePath: string) => Promise<void>;
+
+        beforeEach(async () => {
+            mockExistsSync.mockReturnValue(false);
+
+            await watcher.start(MOCK_ARGS);
+
+            changeHandler = getFileChangeHandler();
+        });
+
+        it("executes command on valid file change event", async () => {
+            mockExistsSync.mockReturnValue(false);
+
+            await changeHandler("change", TEST_FILE_PATH);
+            await mockDebouncedExecution();
+
+            expect(mockCommand.execute).toHaveBeenCalledWith(MOCK_ARGS);
+        });
+
+        it("ignores events not in watchEvents list", async () => {
+            await changeHandler("addDir", "/some/directory");
+            await mockDebouncedExecution();
+
+            expect(mockCommand.execute).not.toHaveBeenCalled();
+        });
+
+        it("handles config file changes", async () => {
+            const configPath = path.join(process.cwd(), CONFIG_FILE_NAME);
+            const { log } = await import("node:console");
+
+            await changeHandler("change", "/some/other/file.ts");
+            await mockDebouncedExecution();
+            await changeHandler("change", configPath);
+
+            expect(log).toHaveBeenCalledWith(
+                expect.stringContaining(`${CONFIG_FILE_NAME} has been modified`),
+            );
+        });
+
+        it("queues execution when lock file exists", async () => {
+            mockExistsSync.mockReturnValue(true);
+
+            const mockWatcherClose = vi.fn();
+
+            // mock fs.watch to immediately call the callback with "rename" event
+            mockWatchFs.mockImplementation((_filePath, _options, callback) => {
+                // simulate lock file being removed after a short delay
+                setTimeout(() => {
+                    callback("rename");
+                }, 50);
+
+                return { "close": mockWatcherClose };
+            });
+
+            // wait for the change to process
+            await changeHandler("change", TEST_FILE_PATH);
+
+            expect(mockWatchFs).toHaveBeenCalledWith(
+                expect.stringContaining("specify-core-watch.lock"),
+                expect.any(Object),
+                expect.any(Function),
+            );
+
+            expect(mockWatcherClose).toHaveBeenCalled();
+        });
+    });
+
+    describe("command execution", () => {
+
+        beforeEach(async () => {
+            mockExistsSync.mockReturnValue(false);
+
+            await watcher.start(MOCK_ARGS);
+        });
+
+        it("creates and removes lock file during execution", async () => {
+            const expectation   = expect.stringContaining("specify-core-watch.lock");
+            const changeHandler = getFileChangeHandler();
+
+            await changeHandler("change", TEST_FILE_PATH);
+            await mockDebouncedExecution();
+
+            expect(mockWriteFileSync).toHaveBeenCalledWith(expectation, "");
+            expect(mockUnlinkSync).toHaveBeenCalledWith(expectation);
+        });
+
+        it("handles command execution errors gracefully", async () => {
+            const error = new Error("Test execution error");
+
+            mockCommand.execute = vi.fn().mockRejectedValue(error);
+
+            const changeHandler = getFileChangeHandler();
+
+            await changeHandler("change", TEST_FILE_PATH);
+            await mockDebouncedExecution();
+
+            // expect the lock file to be cleaned up even on error
+            expect(mockUnlinkSync).toHaveBeenCalled();
+        });
+
+        it("handles command result errors", async () => {
+            const errorResult = {
+                "ok":    false,
+                "error": { "message": "Command failed" },
+            };
+
+            mockCommand.execute = vi.fn().mockResolvedValue(errorResult);
+
+            const changeHandler = getFileChangeHandler();
+
+            await changeHandler("change", TEST_FILE_PATH);
+            await mockDebouncedExecution();
+
+            expect(mockCommand.execute).toHaveBeenCalled();
+            expect(mockUnlinkSync).toHaveBeenCalled();
+        });
+    });
+
+    describe("lock file watching", () => {
+        it("resolves when lock file is removed", async () => {
+            const mockWatcherClose  = vi.fn();
+            const mockEventCallback = vi.fn();
+
+            mockWatchFs.mockImplementation((_filePath, _options, callback) => {
+                mockEventCallback.mockImplementation(callback);
+
+                return { "close": mockWatcherClose };
+            });
+
+            // start the watcher
+            setupMockExistsSync(false);
+
+            await watcher.start(MOCK_ARGS);
+
+            // simulate file change with lock file present
+            setupMockExistsSync(true);
+
+            const onChangeHandler = getFileChangeHandler();
+
+            // start the change handler (don't await to test the lock waiting)
+            const changePromise = onChangeHandler("change", "/some/file.ts");
+
+            // simulate lock file removal
+            setTimeout(() => {
+                mockEventCallback("rename");
+            }, 100);
+
+            await changePromise;
+
+            expect(mockWatcherClose).toHaveBeenCalled();
+        });
+    });
+});

--- a/modules/@specify/core/src/lib/TestCommandWatcher.test.ts
+++ b/modules/@specify/core/src/lib/TestCommandWatcher.test.ts
@@ -90,8 +90,7 @@ describe("TestCommandWatcher", () => {
         return allCall?.[1] as (event: string, filePath: string) => Promise<void>;
     };
 
-    const expectLockFile      = () => expect.stringContaining(LOCK_FILE_NAME);
-    const setupMockExistsSync = (value: boolean) => mockExistsSync.mockReturnValue(value);
+    const expectLockFile = () => expect.stringContaining(LOCK_FILE_NAME);
 
     beforeEach(() => {
         const { config } = createMockConfig();
@@ -113,25 +112,7 @@ describe("TestCommandWatcher", () => {
         watcher = new TestCommandWatcher(mockCommand);
     });
 
-    describe("constructor()", () => {
-        it("initializes with TestCommand instance", () => {
-            expect(watcher).toBeInstanceOf(TestCommandWatcher);
-        });
-    });
-
     describe("start()", () => {
-        let processExitSpy: ReturnType<typeof vi.spyOn>;
-
-        beforeEach(() => {
-            setupMockExistsSync(false);
-
-            processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
-        });
-
-        afterEach(() => {
-            processExitSpy.mockRestore();
-        });
-
         it("clears console and starts watching configured paths", async () => {
             const { clear } = await import("node:console");
 
@@ -169,7 +150,7 @@ describe("TestCommandWatcher", () => {
         });
 
         it("removes existing lock file on start", async () => {
-            mockExistsSync.mockReturnValue(true);
+            mockExistsSync.mockReturnValueOnce(true);
 
             await watcher.start(MOCK_ARGS);
 
@@ -187,16 +168,12 @@ describe("TestCommandWatcher", () => {
         let changeHandler: (event: string, filePath: string) => Promise<void>;
 
         beforeEach(async () => {
-            mockExistsSync.mockReturnValue(false);
-
             await watcher.start(MOCK_ARGS);
 
             changeHandler = getFileChangeHandler();
         });
 
         it("executes command on valid file change event", async () => {
-            mockExistsSync.mockReturnValue(false);
-
             await changeHandler("change", TEST_FILE_PATH);
             await mockDebouncedExecution();
 
@@ -224,7 +201,7 @@ describe("TestCommandWatcher", () => {
         });
 
         it("queues execution when lock file exists", async () => {
-            mockExistsSync.mockReturnValue(true);
+            mockExistsSync.mockReturnValueOnce(true);
 
             const mockWatcherClose = vi.fn();
 
@@ -253,8 +230,6 @@ describe("TestCommandWatcher", () => {
 
     describe("command execution", () => {
         beforeEach(async () => {
-            mockExistsSync.mockReturnValue(false);
-
             await watcher.start(MOCK_ARGS);
         });
 
@@ -313,12 +288,10 @@ describe("TestCommandWatcher", () => {
             });
 
             // start the watcher
-            setupMockExistsSync(false);
-
             await watcher.start(MOCK_ARGS);
 
             // simulate file change with lock file present
-            setupMockExistsSync(true);
+            mockExistsSync.mockReturnValueOnce(true);
 
             const onChangeHandler = getFileChangeHandler();
 

--- a/modules/@specify/core/src/lib/TestCommandWatcher.ts
+++ b/modules/@specify/core/src/lib/TestCommandWatcher.ts
@@ -1,0 +1,254 @@
+/**
+ * TestCommandWatcher class module
+ *
+ * A decorator for TestCommand that provides file watching functionality with
+ * debounced execution to run tests when files change.
+ */
+
+import _                    from "lodash";
+import chalk                from "chalk";
+import { watch            } from "chokidar";
+import { clear, log       } from "node:console";
+import fs                   from "node:fs";
+import os                   from "node:os";
+import path                 from "node:path";
+import { deserializeError } from "serialize-error";
+import { config           } from "@/config/all";
+
+import type { ParsedArgs  } from "minimist";
+import type { TestCommand } from "./TestCommand";
+
+export interface ITestCommandWatcherOptions {
+    debounceMs?: number;
+    packageName?: string;
+}
+
+const DEBOUNCE_MS  = 500;
+const PACKAGE_NAME = "@specify/core";
+
+export class TestCommandWatcher {
+    /**
+     * The TestCommand instance to execute when files change.
+     */
+    #command: TestCommand;
+
+    /**
+     * Configuration object for accessing debug settings.
+     */
+    #config = config;
+
+    /**
+     * Whether or not debug mode is enabled.
+     *
+     * @remarks
+     * The global debug setting is used, but it can be overridden by the watch
+     * configuration.
+     */
+    #debug = this.#config.debug || this.#config.watch.debug;
+
+    /**
+     * Path to the lock file used to prevent concurrent executions.
+     */
+    #lockFilePath: string;
+
+    /**
+     * Flag to track if an execution is currently queued.
+     */
+    #executionQueued: boolean = false;
+
+    /**
+     * Patterns to ignore when watching files.
+     */
+    #ignoredPatterns: RegExp[] = this.#config.watch.ignore.map(
+        (ignorePattern) => new RegExp(ignorePattern),
+    );
+
+    /**
+     * Events to watch for file system changes.
+     */
+    #watchEvents: string[] = this.#config.watch.events ?? [
+        "add",
+        "change",
+        "unlink",
+    ];
+
+    /**
+     * Flag to track if this is the initial execution.
+     */
+    #initialExecution: boolean = true;
+
+    /**
+     * Debounced execution function.
+     */
+    #debouncedExecution: ReturnType<typeof _.debounce>;
+
+    /**
+     * Prompt prefix for console output.
+     */
+    #promptPrefix: string;
+
+    /**
+     * Initialize the TestCommandWatcher.
+     *
+     * @param command - The TestCommand instance to watch and execute
+     */
+    constructor(command: TestCommand) {
+        this.#command = command;
+        this.#lockFilePath = path.join(os.tmpdir(), `specify-core-watch.lock`);
+        this.#promptPrefix =
+            chalk.cyan("[") + chalk.greenBright(PACKAGE_NAME) + chalk.cyan("]");
+
+        this.#debouncedExecution = _.debounce(
+            this.#executeCommand.bind(this),
+            DEBOUNCE_MS,
+        );
+    }
+
+    /**
+     * Log debug messages when debug mode is enabled.
+     *
+     * @param message - The debug message to log
+     * @param data    - Optional additional data to log
+     * @param force   - Whether to force logging even if debug is disabled
+     */
+    #debugLog(message: string, data?: unknown, force?: boolean): void {
+        if (!this.#debug && !force) {
+            return;
+        }
+
+        const debugMessage = `${this.#promptPrefix}${chalk.gray("[DEBUG]")} ${message}`;
+
+        log(debugMessage);
+
+        if (data !== undefined) {
+            log(chalk.gray(JSON.stringify(data, null, 2)));
+        }
+    }
+
+    /**
+     * Start watching for file changes and execute the command when changes occur.
+     *
+     * @param args - Command line arguments to pass to the TestCommand
+     */
+    async start(args: ParsedArgs): Promise<void> {
+        clear();
+
+        const watchPaths = config.watch.paths.map((watchPath) =>
+            path.resolve(watchPath),
+        );
+
+        if (watchPaths.length === 0) {
+            log(
+                `${this.#promptPrefix} No watch paths configured. Please set "watch.paths" in specify.config.json.`,
+            );
+            log(`${this.#promptPrefix} Exiting...`);
+
+            process.exit(1);
+        }
+
+        // remove the lock file if it exists (to ensure a clean start)
+        if (fs.existsSync(this.#lockFilePath)) {
+            fs.unlinkSync(this.#lockFilePath);
+        }
+
+        watch(watchPaths, {
+            "ignored":    this.#ignoredPatterns,
+            "persistent": true,
+        }).on("all", async (event, filePath) => {
+            this.#debugLog(`Detected ${event} event for ${filePath}`);
+
+            if (this.#executionQueued) {
+                this.#debugLog("Execution prevented: already queued.");
+
+                return;
+            }
+
+            if (this.#watchEvents.includes(event)) {
+                if (
+                    fs.existsSync(this.#lockFilePath) &&
+                    !this.#executionQueued
+                ) {
+                    this.#executionQueued = true;
+
+                    if (this.#initialExecution) {
+                        this.#debugLog(
+                            "Skipping queue: initial execution running.",
+                        );
+
+                        return;
+                    }
+
+                    this.#debugLog(
+                        `Execution queued: waiting for lock file removal (${chalk.gray(this.#lockFilePath)})...`,
+                    );
+
+                    await new Promise<void>((resolve) => {
+                        const watcher = fs.watch(
+                            this.#lockFilePath,
+                            { "persistent": true },
+                            (eventType) => {
+                                // there are only 2 event types here: rename and change
+                                // rename indicates the file was deleted, moved, or otherwise isn't there anymore
+                                if (eventType === "rename") {
+                                    this.#debugLog(
+                                        "Lock file removed, proceeding with queued execution.",
+                                    );
+
+                                    watcher.close();
+                                    resolve();
+                                }
+                            },
+                        );
+                    });
+                }
+
+                this.#debugLog(
+                    `Triggering debounced execution (debounced ${DEBOUNCE_MS}ms)...`,
+                );
+
+                void this.#debouncedExecution(args);
+            }
+        });
+    }
+
+    /**
+     * Execute the TestCommand with proper error handling and lock file management.
+     *
+     * @param args - Command line arguments to pass to the TestCommand
+     */
+    async #executeCommand(args: ParsedArgs): Promise<void> {
+        try {
+            this.#debugLog(
+                `Creating lock file (${chalk.gray(this.#lockFilePath)})...`,
+            );
+
+            fs.writeFileSync(this.#lockFilePath, "");
+
+            this.#debugLog(
+                `Executing test command (initial execution? ${this.#initialExecution ? "yes" : "no"})...`,
+            );
+
+            const res = await this.#command.execute(args);
+
+            if (res.error) {
+                throw deserializeError(res.error);
+            }
+        } catch (error) {
+            this.#debugLog(
+                `Error executing command: ${error instanceof Error ? error.message : String(error)}`,
+                error,
+                true,
+            );
+        } finally {
+            this.#debugLog(
+                `Removing lock file (${chalk.gray(this.#lockFilePath)}) and resetting state...`,
+            );
+            fs.unlinkSync(this.#lockFilePath);
+
+            log(`\n${this.#promptPrefix} Watching for changes...\n`);
+
+            this.#executionQueued = false;
+            this.#initialExecution = false;
+        }
+    }
+}

--- a/modules/@specify/core/src/lib/TestCommandWatcher.ts
+++ b/modules/@specify/core/src/lib/TestCommandWatcher.ts
@@ -23,7 +23,8 @@ export interface ITestCommandWatcherOptions {
     packageName?: string;
 }
 
-const DEBOUNCE_MS  = 500;
+export const DEBOUNCE_MS = 500;
+
 const PACKAGE_NAME = "@specify/core";
 
 export class TestCommandWatcher {

--- a/modules/@specify/core/src/lib/TestCommandWatcher.ts
+++ b/modules/@specify/core/src/lib/TestCommandWatcher.ts
@@ -58,9 +58,7 @@ export class TestCommandWatcher {
     /**
      * Patterns to ignore when watching files.
      */
-    #ignoredPatterns = this.#config.watch.ignore.map(
-        (ignorePattern) => new RegExp(ignorePattern),
-    );
+    #ignoredPatterns = this.#config.watch.ignore.map((ignorePattern) => new RegExp(ignorePattern));
 
     /**
      * Flag to track if this is the initial execution.
@@ -85,11 +83,7 @@ export class TestCommandWatcher {
     /**
      * Events to watch for file system changes.
      */
-    #watchEvents: string[] = this.#config.watch.events ?? [
-        "add",
-        "change",
-        "unlink",
-    ];
+    #watchEvents: string[] = this.#config.watch.events ?? ["add", "change", "unlink"];
 
     /**
      * Initialize the TestCommandWatcher.
@@ -99,13 +93,9 @@ export class TestCommandWatcher {
     constructor(command: TestCommand) {
         this.#command = command;
         this.#lockFilePath = path.join(os.tmpdir(), "specify-core-watch.lock");
-        this.#promptPrefix =
-            chalk.cyan("[") + chalk.greenBright(PACKAGE_NAME) + chalk.cyan("]");
+        this.#promptPrefix = chalk.cyan("[") + chalk.greenBright(PACKAGE_NAME) + chalk.cyan("]");
 
-        this.#debouncedExecution = _.debounce(
-            this.#executeCommand.bind(this),
-            DEBOUNCE_MS,
-        );
+        this.#debouncedExecution = _.debounce(this.#executeCommand.bind(this), DEBOUNCE_MS);
     }
 
     /**
@@ -136,9 +126,7 @@ export class TestCommandWatcher {
      */
     async #executeCommand(args: ParsedArgs): Promise<void> {
         try {
-            this.#debugLog(
-                `Creating lock file (${chalk.gray(this.#lockFilePath)})...`,
-            );
+            this.#debugLog(`Creating lock file (${chalk.gray(this.#lockFilePath)})...`);
 
             fs.writeFileSync(this.#lockFilePath, "");
 
@@ -151,15 +139,9 @@ export class TestCommandWatcher {
             if (res.error) {
                 const resError     = deserializeError(res.error);
                 const errorMessage =
-                    resError instanceof Error
-                        ? resError.message
-                        : String(resError);
+                    resError instanceof Error ? resError.message : String(resError);
 
-                this.#debugLog(
-                    `Command execution failed: ${errorMessage}`,
-                    resError,
-                    true,
-                );
+                this.#debugLog(`Command execution failed: ${errorMessage}`, resError, true);
             }
         } catch (error) {
             this.#debugLog(
@@ -227,9 +209,7 @@ export class TestCommandWatcher {
     async start(args: ParsedArgs): Promise<void> {
         clear();
 
-        const watchPaths = config.watch.paths.map((watchPath) =>
-            path.resolve(watchPath),
-        );
+        const watchPaths = config.watch.paths.map((watchPath) => path.resolve(watchPath));
 
         if (watchPaths.length === 0) {
             log(
@@ -266,10 +246,7 @@ export class TestCommandWatcher {
             }
 
             if (this.#watchEvents.includes(event)) {
-                if (
-                    fs.existsSync(this.#lockFilePath) &&
-                    !this.#executionQueued
-                ) {
+                if (fs.existsSync(this.#lockFilePath) && !this.#executionQueued) {
                     this.#queueExecution();
 
                     this.#debugLog(
@@ -279,9 +256,7 @@ export class TestCommandWatcher {
                     await this.#waitForLockFileRemoval();
                 }
 
-                this.#debugLog(
-                    `Triggering debounced execution (debounced ${DEBOUNCE_MS}ms)...`,
-                );
+                this.#debugLog(`Triggering debounced execution (debounced ${DEBOUNCE_MS}ms)...`);
 
                 void this.#debouncedExecution(args);
             }
@@ -293,20 +268,16 @@ export class TestCommandWatcher {
      */
     async #waitForLockFileRemoval(): Promise<void> {
         return new Promise<void>((resolve) => {
-            const watcher = fs.watch(
-                this.#lockFilePath,
-                { "persistent": true },
-                (eventType) => {
-                    // there are only 2 event types here: rename and change
-                    // rename indicates the file was deleted, moved, or otherwise isn't there anymore
-                    if (eventType === "rename") {
-                        this.#debugLog("Lock file removed.");
+            const watcher = fs.watch(this.#lockFilePath, { "persistent": true }, (eventType) => {
+                // there are only 2 event types here: rename and change
+                // rename indicates the file was deleted, moved, or otherwise isn't there anymore
+                if (eventType === "rename") {
+                    this.#debugLog("Lock file removed.");
 
-                        watcher.close();
-                        resolve();
-                    }
-                },
-            );
+                    watcher.close();
+                    resolve();
+                }
+            });
         });
     }
 }

--- a/modules/@specify/core/src/lib/TestCommandWatcher.ts
+++ b/modules/@specify/core/src/lib/TestCommandWatcher.ts
@@ -41,8 +41,7 @@ export class TestCommandWatcher {
      * Whether or not debug mode is enabled.
      *
      * @remarks
-     * The global debug setting is used, but it can be overridden by the watch
-     * configuration.
+     * The global debug setting takes precedence over the watch config setting.
      */
     #debug = this.#config.debug || this.#config.watch.debug;
 
@@ -99,7 +98,7 @@ export class TestCommandWatcher {
      */
     constructor(command: TestCommand) {
         this.#command = command;
-        this.#lockFilePath = path.join(os.tmpdir(), `specify-core-watch.lock`);
+        this.#lockFilePath = path.join(os.tmpdir(), "specify-core-watch.lock");
         this.#promptPrefix =
             chalk.cyan("[") + chalk.greenBright(PACKAGE_NAME) + chalk.cyan("]");
 
@@ -110,7 +109,7 @@ export class TestCommandWatcher {
     }
 
     /**
-     * Log debug messages when debug mode is enabled.
+     * Log debug messages when debug mode is enabled or force logging is requested.
      *
      * @param message - The debug message to log
      * @param data    - Optional additional data to log
@@ -131,7 +130,7 @@ export class TestCommandWatcher {
     }
 
     /**
-     * Execute the TestCommand with proper error handling and lock file management.
+     * Execute the TestCommand.
      *
      * @param args - Command line arguments to pass to the TestCommand
      */
@@ -172,7 +171,7 @@ export class TestCommandWatcher {
     }
 
     /**
-     * Check if the configuration file has changed based on the file path.
+     * Check if the configuration file has changed.
      */
     #hasConfigChanged(filePath: string): boolean {
         if (!this.#initialExecution) {
@@ -280,7 +279,7 @@ export class TestCommandWatcher {
     }
 
     /**
-     * Wait for the lock file to be removed before proceeding with execution.
+     * Wait for the lock file to be removed.
      */
     async #waitForLockFileRemoval(): Promise<void> {
         return new Promise<void>((resolve) => {

--- a/modules/@specify/core/src/lib/TestCommandWatcher.ts
+++ b/modules/@specify/core/src/lib/TestCommandWatcher.ts
@@ -213,12 +213,9 @@ export class TestCommandWatcher {
         const watchPaths = config.watch.paths.map((watchPath) => path.resolve(watchPath));
 
         if (watchPaths.length === 0) {
-            log(
-                `${this.#promptPrefix} No watch paths configured. Please set "watch.paths" in specify.config.json.`,
-            );
-            log(`${this.#promptPrefix} Exiting...`);
+            this.#debugLog("No watch paths specified, defaulting to current working directory.");
 
-            process.exit(1);
+            watchPaths.push(process.cwd());
         }
 
         // remove the lock file if it exists (to ensure a clean start)

--- a/modules/@specify/core/src/lib/TestCommandWatcher.ts
+++ b/modules/@specify/core/src/lib/TestCommandWatcher.ts
@@ -300,9 +300,7 @@ export class TestCommandWatcher {
                     // there are only 2 event types here: rename and change
                     // rename indicates the file was deleted, moved, or otherwise isn't there anymore
                     if (eventType === "rename") {
-                        this.#debugLog(
-                            "Lock file removed, proceeding with queued execution.",
-                        );
+                        this.#debugLog("Lock file removed.");
 
                         watcher.close();
                         resolve();

--- a/modules/@specify/core/src/lib/TestCommandWatcher.ts
+++ b/modules/@specify/core/src/lib/TestCommandWatcher.ts
@@ -54,19 +54,19 @@ export class TestCommandWatcher {
     /**
      * Flag to track if an execution is currently queued.
      */
-    #executionQueued: boolean = false;
+    #executionQueued = false;
 
     /**
      * Patterns to ignore when watching files.
      */
-    #ignoredPatterns: RegExp[] = this.#config.watch.ignore.map(
+    #ignoredPatterns = this.#config.watch.ignore.map(
         (ignorePattern) => new RegExp(ignorePattern),
     );
 
     /**
      * Flag to track if this is the initial execution.
      */
-    #initialExecution: boolean = true;
+    #initialExecution = true;
 
     /**
      * Path to the lock file used to prevent concurrent executions.
@@ -81,7 +81,7 @@ export class TestCommandWatcher {
     /**
      * Flag to indicate if a restart is required due to configuration changes.
      */
-    #restartRequired: boolean = false;
+    #restartRequired = false;
 
     /**
      * Events to watch for file system changes.

--- a/modules/@specify/core/src/lib/TestCommandWatcher.ts
+++ b/modules/@specify/core/src/lib/TestCommandWatcher.ts
@@ -210,17 +210,13 @@ export class TestCommandWatcher {
      * Queue the execution of the command, setting the flag to prevent multiple executions.
      */
     #queueExecution(): void {
-        this.#executionQueued = true;
-
         if (this.#initialExecution) {
             this.#debugLog("Skipping queue: initial execution running.");
 
             return;
         }
 
-        this.#debugLog(
-            `Execution queued: waiting for lock file removal (${chalk.gray(this.#lockFilePath)})...`,
-        );
+        this.#executionQueued = true;
     }
 
     /**
@@ -275,6 +271,10 @@ export class TestCommandWatcher {
                     !this.#executionQueued
                 ) {
                     this.#queueExecution();
+
+                    this.#debugLog(
+                        `Execution queued: waiting for lock file removal (${chalk.gray(this.#lockFilePath)})...`,
+                    );
 
                     await this.#waitForLockFileRemoval();
                 }

--- a/modules/@specify/core/src/lib/TestCommandWatcher.ts
+++ b/modules/@specify/core/src/lib/TestCommandWatcher.ts
@@ -149,7 +149,17 @@ export class TestCommandWatcher {
             const res = await this.#command.execute(args);
 
             if (res.error) {
-                throw deserializeError(res.error);
+                const resError     = deserializeError(res.error);
+                const errorMessage =
+                    resError instanceof Error
+                        ? resError.message
+                        : String(resError);
+
+                this.#debugLog(
+                    `Command execution failed: ${errorMessage}`,
+                    resError,
+                    true,
+                );
             }
         } catch (error) {
             this.#debugLog(

--- a/modules/@specify/core/src/main.ts
+++ b/modules/@specify/core/src/main.ts
@@ -9,7 +9,7 @@
 import merge                from "deepmerge";
 import minimist             from "minimist";
 import { log              } from "node:console";
-import path                 from "path";
+import path                 from "node:path";
 import { deserializeError } from "serialize-error";
 
 import { config                } from "@/config/all";
@@ -55,7 +55,7 @@ cucumberCfg.import.push(path.resolve(import.meta.dirname, "cucumber"));
 switch (args._[0]?.toLowerCase()) {
     case "test":
         args._.shift();
-    // fall through to default
+        // fall through to default
     default:
         cmd = new TestCommand({
             "cucumber":     cucumberCfg,

--- a/modules/@specify/core/src/main.ts
+++ b/modules/@specify/core/src/main.ts
@@ -6,25 +6,18 @@
  * A Cucumber-based testing tool built to support behavior-driven development.
  */
 
-import _                    from "lodash";
-import chalk                from "chalk";
-import { watch            } from "chokidar";
 import merge                from "deepmerge";
 import minimist             from "minimist";
-import { clear, log       } from "node:console";
-import fs                   from "node:fs";
-import os                   from "node:os";
-import path                 from "node:path";
+import path                 from "path";
 import { deserializeError } from "serialize-error";
 
 import { config                } from "@/config/all";
 import { Command, SPECIFY_ARGS } from "./lib/Command";
+import { TestCommandWatcher    } from "./lib/TestCommandWatcher";
 
 import type { ISpecifyArgs } from "./lib/Command";
 
 import { TestCommand, TEST_COMMAND_DEFAULT_OPTS } from "./lib/TestCommand";
-
-const PACKAGE_NAME = "@specify/core";
 
 const getSpecifyArgs = (args: minimist.ParsedArgs): ISpecifyArgs => {
     return Object.entries(args)
@@ -79,98 +72,9 @@ switch (args._[0]?.toLowerCase()) {
 }
 
 if (specifyArgs.watch) {
-    clear();
+    const watcher = new TestCommandWatcher(cmd as TestCommand);
 
-    const promptPrefix =
-        chalk.cyan("[") + chalk.greenBright(PACKAGE_NAME) + chalk.cyan("]");
-    const lockFilePath = path.join(os.tmpdir(), `specify-core-watch.lock`);
-    const watchPaths   = config.paths.watch?.paths.map((watchPath) =>
-        path.resolve(watchPath),
-    );
-
-    if (!watchPaths || watchPaths.length === 0) {
-        log(
-            `${promptPrefix} No watch paths configured. Please set "paths.watch.paths" in specify.config.json.`,
-        );
-        log(`${promptPrefix} Exiting...`);
-
-        process.exit(1);
-    }
-
-    // remove the lock file if it exists (to ensure a clean start)
-    if (fs.existsSync(lockFilePath)) {
-        fs.unlinkSync(lockFilePath);
-    }
-
-    let executionQueued  = false;
-    let initialExecution = true;
-
-    const debouncedExecution = _.debounce(async () => {
-        try {
-            // create the lock file in the temporary directory
-            fs.writeFileSync(lockFilePath, "");
-
-            const res = await cmd.execute(args);
-
-            if (res.error) {
-                throw deserializeError(res.error);
-            }
-        } catch (error) {
-            log("Error executing command:", error);
-        } finally {
-            // remove the lock file after execution
-            fs.unlinkSync(lockFilePath);
-
-            log(`\n${promptPrefix} Watching for changes...\n`);
-
-            executionQueued = false;
-            initialExecution = false;
-        }
-    }, 500);
-
-    watch(
-        config.paths.watch?.paths.map((watchPath) => path.resolve(watchPath)),
-        {
-            "ignored": config.paths.watch?.ignore.map(
-                (ignorePattern) => new RegExp(ignorePattern),
-            ) ?? [/\/node_modules\//],
-            "persistent": true,
-        },
-    ).on("all", async (event) => {
-        if (executionQueued) {
-            return;
-        }
-
-        if (["add", "change", "unlink"].includes(event)) {
-            if (fs.existsSync(lockFilePath) && !executionQueued) {
-                // if a lock file exists, queue the execution and await the removal of the lock file
-                executionQueued = true;
-
-                // the initial execution is already running; don't queue it again
-                if (initialExecution) {
-                    return;
-                }
-
-                await new Promise((resolve) => {
-                    const watcher = fs.watch(
-                        lockFilePath,
-                        { "persistent": true },
-                        (eventType) => {
-                            // there are only 2 event types: rename and change
-                            // rename indicates the file was deleted or moved or otherwise isn't there anymore
-                            if (eventType === "rename") {
-                                watcher.close();
-
-                                resolve(null);
-                            }
-                        },
-                    );
-                });
-            }
-
-            void debouncedExecution();
-        }
-    });
+    await watcher.start(args);
 } else {
     const res = await cmd.execute(args);
 

--- a/modules/@specify/core/src/main.ts
+++ b/modules/@specify/core/src/main.ts
@@ -6,19 +6,37 @@
  * A Cucumber-based testing tool built to support behavior-driven development.
  */
 
+import chalk                from "chalk";
+import { watch            } from "chokidar";
 import merge                from "deepmerge";
 import minimist             from "minimist";
-import { log              } from "node:console";
+import { clear, log       } from "node:console";
+import fs                   from "node:fs";
+import os                   from "node:os";
 import path                 from "node:path";
 import { deserializeError } from "serialize-error";
 
-import { config  } from "@/config/all";
-import { Command } from "./lib/Command";
+import { config                } from "@/config/all";
+import { Command, SPECIFY_ARGS } from "./lib/Command";
+
+import type { ISpecifyArgs } from "./lib/Command";
 
 import { TestCommand, TEST_COMMAND_DEFAULT_OPTS } from "./lib/TestCommand";
 
-const minOpts = {};
-const args    = minimist(process.argv.slice(2), minOpts);
+const PACKAGE_NAME = "@specify/core";
+
+const getSpecifyArgs = (args: minimist.ParsedArgs): ISpecifyArgs => {
+    return Object.entries(args)
+        .filter(([key]) => SPECIFY_ARGS.includes(key))
+        .reduce((acc, [key, value]) => {
+            acc[key] = value;
+            return acc;
+        }, {});
+};
+
+const minOpts     = {};
+const args        = minimist(process.argv.slice(2), minOpts);
+const specifyArgs = getSpecifyArgs(args);
 
 let cucumberCfg = config.cucumber;
 let cmd: Command;
@@ -48,14 +66,115 @@ switch (args._[0]?.toLowerCase()) {
             "cucumber":     cucumberCfg,
             "debug":        config.debug,
             "gherkinPaths": [path.resolve(config.paths.gherkin)],
-            "logPath":      path.resolve(config.paths.logs, TEST_COMMAND_DEFAULT_OPTS.logPath),
+            "logPath":      path.resolve(
+                config.paths.logs,
+                TEST_COMMAND_DEFAULT_OPTS.logPath,
+            ),
+            "plugins": [
+                ...config.plugins,
+                path.resolve(import.meta.dirname, "../dist/cucumber"),
+            ],
         });
 }
 
-const res = await cmd.execute(args);
+if (specifyArgs.watch) {
+    clear();
 
-if (res.error) {
-    log(res.debug ? deserializeError(res.error) : deserializeError(res.error).message);
+    const promptPrefix =
+        chalk.cyan("[") + chalk.greenBright(PACKAGE_NAME) + chalk.cyan("]");
+    const lockFilePath = path.join(os.tmpdir(), `specify-core-watch.lock`);
+    const watchPaths   = config.paths.watch?.paths.map((watchPath) =>
+        path.resolve(watchPath),
+    );
+
+    if (!watchPaths || watchPaths.length === 0) {
+        log(
+            `${promptPrefix} No watch paths configured. Please set "paths.watch.paths" in specify.config.json.`,
+        );
+        log(`${promptPrefix} Exiting...`);
+
+        process.exit(1);
+    }
+
+    // remove the lock file if it exists (to ensure a clean start)
+    if (fs.existsSync(lockFilePath)) {
+        fs.unlinkSync(lockFilePath);
+    }
+
+    let executionQueued  = false;
+    let initialExecution = true;
+
+    watch(
+        config.paths.watch?.paths.map((watchPath) => path.resolve(watchPath)),
+        {
+            "ignored": config.paths.watch?.ignore.map(
+                (ignorePattern) => new RegExp(ignorePattern),
+            ) ?? [/\/node_modules\//, /\/dist\//],
+            "persistent": true,
+        },
+    ).on("all", async (event) => {
+        if (executionQueued) {
+            return;
+        }
+
+        if (["add", "change", "unlink"].includes(event)) {
+            if (fs.existsSync(lockFilePath) && !executionQueued) {
+                // if a lock file exists, queue the execution and await the removal of the lock file
+                executionQueued = true;
+
+                // the initial execution is already running; don't queue it again
+                if (initialExecution) {
+                    return;
+                }
+
+                await new Promise((resolve) => {
+                    const watcher = fs.watch(
+                        lockFilePath,
+                        { "persistent": true },
+                        (eventType) => {
+                            // there are only 2 event types: rename and change
+                            // rename indicates the file was deleted or moved or otherwise isn't there anymore
+                            if (eventType === "rename") {
+                                watcher.close();
+
+                                resolve(null);
+                            }
+                        },
+                    );
+                });
+            }
+
+            try {
+                // create the lock file in the temporary directory
+                fs.writeFileSync(lockFilePath, "");
+
+                const res = await cmd.execute(args);
+
+                if (res.error) {
+                    throw deserializeError(res.error);
+                }
+            } catch (error) {
+                log("Error executing command:", error);
+            } finally {
+                // remove the lock file after executionasd
+                fs.unlinkSync(lockFilePath);
+
+                log(`\n${promptPrefix} Watching for changes...\n`);
+
+                executionQueued = false;
+                initialExecution = false;
+            }
+        }
+    });
+} else {
+    const res = await cmd.execute(args);
+
+    if (res.error) {
+        log((res.debug)
+            ? deserializeError(res.error)
+            : deserializeError(res.error).message
+        )
+    }
+
+    process.exit(res.status);
 }
-
-process.exit(res.status);

--- a/modules/@specify/core/src/main.ts
+++ b/modules/@specify/core/src/main.ts
@@ -28,7 +28,7 @@ const getSpecifyArgs = (args: minimist.ParsedArgs): ISpecifyArgs => {
         }, {});
 };
 
-const minOpts     = {};
+const minOpts     = { "boolean": SPECIFY_ARGS };
 const args        = minimist(process.argv.slice(2), minOpts);
 const specifyArgs = getSpecifyArgs(args);
 

--- a/modules/@specify/core/src/main.ts
+++ b/modules/@specify/core/src/main.ts
@@ -55,20 +55,13 @@ cucumberCfg.import.push(path.resolve(import.meta.dirname, "cucumber"));
 switch (args._[0]?.toLowerCase()) {
     case "test":
         args._.shift();
-        // fall through to default
+    // fall through to default
     default:
         cmd = new TestCommand({
             "cucumber":     cucumberCfg,
             "debug":        config.debug,
             "gherkinPaths": [path.resolve(config.paths.gherkin)],
-            "logPath":      path.resolve(
-                config.paths.logs,
-                TEST_COMMAND_DEFAULT_OPTS.logPath,
-            ),
-            "plugins": [
-                ...config.plugins,
-                path.resolve(import.meta.dirname, "../dist/cucumber"),
-            ],
+            "logPath":      path.resolve(config.paths.logs, TEST_COMMAND_DEFAULT_OPTS.logPath),
         });
 }
 
@@ -80,11 +73,7 @@ if (specifyArgs.watch) {
     const res = await cmd.execute(args);
 
     if (res.error) {
-        log(
-            res.debug
-                ? deserializeError(res.error)
-                : deserializeError(res.error).message,
-        );
+        log(res.debug ? deserializeError(res.error) : deserializeError(res.error).message);
     }
 
     process.exit(res.status);

--- a/modules/@specify/core/src/main.ts
+++ b/modules/@specify/core/src/main.ts
@@ -6,6 +6,7 @@
  * A Cucumber-based testing tool built to support behavior-driven development.
  */
 
+import _                    from "lodash";
 import chalk                from "chalk";
 import { watch            } from "chokidar";
 import merge                from "deepmerge";
@@ -104,12 +105,35 @@ if (specifyArgs.watch) {
     let executionQueued  = false;
     let initialExecution = true;
 
+    const debouncedExecution = _.debounce(async () => {
+        try {
+            // create the lock file in the temporary directory
+            fs.writeFileSync(lockFilePath, "");
+
+            const res = await cmd.execute(args);
+
+            if (res.error) {
+                throw deserializeError(res.error);
+            }
+        } catch (error) {
+            log("Error executing command:", error);
+        } finally {
+            // remove the lock file after execution
+            fs.unlinkSync(lockFilePath);
+
+            log(`\n${promptPrefix} Watching for changes...\n`);
+
+            executionQueued = false;
+            initialExecution = false;
+        }
+    }, 500);
+
     watch(
         config.paths.watch?.paths.map((watchPath) => path.resolve(watchPath)),
         {
             "ignored": config.paths.watch?.ignore.map(
                 (ignorePattern) => new RegExp(ignorePattern),
-            ) ?? [/\/node_modules\//, /\/dist\//],
+            ) ?? [/\/node_modules\//],
             "persistent": true,
         },
     ).on("all", async (event) => {
@@ -144,26 +168,7 @@ if (specifyArgs.watch) {
                 });
             }
 
-            try {
-                // create the lock file in the temporary directory
-                fs.writeFileSync(lockFilePath, "");
-
-                const res = await cmd.execute(args);
-
-                if (res.error) {
-                    throw deserializeError(res.error);
-                }
-            } catch (error) {
-                log("Error executing command:", error);
-            } finally {
-                // remove the lock file after executionasd
-                fs.unlinkSync(lockFilePath);
-
-                log(`\n${promptPrefix} Watching for changes...\n`);
-
-                executionQueued = false;
-                initialExecution = false;
-            }
+            void debouncedExecution();
         }
     });
 } else {

--- a/modules/@specify/core/src/main.ts
+++ b/modules/@specify/core/src/main.ts
@@ -8,6 +8,7 @@
 
 import merge                from "deepmerge";
 import minimist             from "minimist";
+import { log              } from "node:console";
 import path                 from "path";
 import { deserializeError } from "serialize-error";
 
@@ -79,10 +80,11 @@ if (specifyArgs.watch) {
     const res = await cmd.execute(args);
 
     if (res.error) {
-        log((res.debug)
-            ? deserializeError(res.error)
-            : deserializeError(res.error).message
-        )
+        log(
+            res.debug
+                ? deserializeError(res.error)
+                : deserializeError(res.error).message,
+        );
     }
 
     process.exit(res.status);

--- a/modules/@specify/core/tsconfig.json
+++ b/modules/@specify/core/tsconfig.json
@@ -11,11 +11,9 @@
         }
     },
     "exclude": [
-        "dist",
-        "**/node_modules/**"
+        "dist", "**/node_modules/**"
     ],
     "include": [
-        "./src/**/*.ts",
-        "./src/**/*.json"
+        "./src/**/*.ts", "./src/**/*.json", "package.json"
     ]
 }

--- a/modules/@specify/core/types/index.d.ts
+++ b/modules/@specify/core/types/index.d.ts
@@ -6,4 +6,5 @@ export interface CoreConfig {
     debug: import("../src/config/debug.config").DebugConfig;
     paths: import("../src/config/paths.config").PathsConfig;
     plugins: import("../src/config/plugins.config").PluginsConfig;
+    watch: import("../src/config/watch.config").WatchConfig;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       chokidar:
         specifier: ^4.0.3
         version: 4.0.3
+      deepmerge:
+        specifier: ^4.3.1
+        version: 4.3.1
       globby:
         specifier: ^14.1.0
         version: 14.1.0
@@ -126,9 +129,6 @@ importers:
       serialize-error:
         specifier: ^12.0.0
         version: 12.0.0
-      type-fest:
-        specifier: ^4.41.0
-        version: 4.41.0
     devDependencies:
       '@types/minimist':
         specifier: ^1.2.5
@@ -136,15 +136,15 @@ importers:
       '@types/resolve':
         specifier: ^1.20.6
         version: 1.20.6
-      deepmerge:
-        specifier: ^4.3.1
-        version: 4.3.1
       ts-morph:
         specifier: ^25.0.1
         version: 25.0.1
       tsc-alias:
         specifier: ^1.8.16
         version: 1.8.16
+      type-fest:
+        specifier: ^4.41.0
+        version: 4.41.0
       typescript:
         specifier: ^5.8.3
         version: 5.8.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,12 @@ importers:
       '@specify/quick-ref':
         specifier: workspace:*
         version: link:../quick-ref
+      chalk:
+        specifier: ^5.4.1
+        version: 5.4.1
+      chokidar:
+        specifier: ^4.0.3
+        version: 4.0.3
       globby:
         specifier: ^14.1.0
         version: 14.1.0
@@ -2145,7 +2151,7 @@ snapshots:
   '@eslint/config-array@0.20.0':
     dependencies:
       '@eslint/object-schema': 2.1.6
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -2159,7 +2165,7 @@ snapshots:
   '@eslint/eslintrc@3.3.1':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       espree: 10.3.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -2358,7 +2364,7 @@ snapshots:
       '@typescript-eslint/types': 8.32.1
       '@typescript-eslint/typescript-estree': 8.32.1(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.32.1
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       eslint: 9.27.0(jiti@2.4.2)
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -2391,7 +2397,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 8.32.1(typescript@5.8.3)
       '@typescript-eslint/utils': 8.32.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3)
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       eslint: 9.27.0(jiti@2.4.2)
       ts-api-utils: 2.1.0(typescript@5.8.3)
       typescript: 5.8.3
@@ -2406,7 +2412,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.32.1
       '@typescript-eslint/visitor-keys': 8.32.1
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -2660,10 +2666,6 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  debug@4.4.1:
-    dependencies:
-      ms: 2.1.3
-
   debug@4.4.1(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
@@ -2783,7 +2785,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.3.0
       eslint-visitor-keys: 4.2.0
@@ -3532,7 +3534,7 @@ snapshots:
   vite-node@3.2.4(@types/node@22.15.18)(jiti@2.4.2)(tsx@4.19.4)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 7.0.0(@types/node@22.15.18)(jiti@2.4.2)(tsx@4.19.4)(yaml@2.8.0)
@@ -3576,7 +3578,7 @@ snapshots:
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
       chai: 5.2.0
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       expect-type: 1.2.1
       magic-string: 0.30.17
       pathe: 2.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       globby:
         specifier: ^14.1.0
         version: 14.1.0
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
       minimist:
         specifier: ^1.2.8
         version: 1.2.8

--- a/specify.config.json
+++ b/specify.config.json
@@ -5,24 +5,24 @@
     },
     "debug": false,
     "paths": {
-        "logs": "./logs",
-        "watch": {
-            "paths": [
-                "./features",
-                "./modules/@specify/core/dist",
-                "./modules/@specify/plugin-cli/dist",
-                "./modules/@specify/quick-ref/dist"
-            ],
-            "ignore": [
-                "\\.test\\.ts$",
-                "\\.spec\\.ts$",
-                "__tests__",
-                "__mocks__",
-                "\\.d\\.ts$",
-                "\\/node_modules\\/",
-                "\\.git"
-            ]
-        }
+        "logs": "./logs"
+    },
+    "watch": {
+        "paths": [
+            "./features",
+            "./modules/@specify/core/dist",
+            "./modules/@specify/plugin-cli/dist",
+            "./modules/@specify/quick-ref/dist"
+        ],
+        "ignore": [
+            "\\.test\\.ts$",
+            "\\.spec\\.ts$",
+            "__tests__",
+            "__mocks__",
+            "\\.d\\.ts$",
+            "\\/node_modules\\/",
+            "\\.git"
+        ]
     },
     "plugins": [ "@specify/plugin-cli" ]
 }

--- a/specify.config.json
+++ b/specify.config.json
@@ -15,6 +15,7 @@
             "./modules/@specify/quick-ref/dist"
         ],
         "ignore": [
+            "\\/logs\\/",
             "\\.test\\.ts$",
             "\\.spec\\.ts$",
             "__tests__",

--- a/specify.config.json
+++ b/specify.config.json
@@ -1,7 +1,28 @@
 {
+    "cucumber": {
+        "format": [ "progress" ],
+        "parallel": 3
+    },
     "debug": false,
     "paths": {
-        "logs": "./logs"
+        "logs": "./logs",
+        "watch": {
+            "paths": [
+                "./features",
+                "./modules/@specify/core/dist",
+                "./modules/@specify/plugin-cli/dist",
+                "./modules/@specify/quick-ref/dist"
+            ],
+            "ignore": [
+                "\\.test\\.ts$",
+                "\\.spec\\.ts$",
+                "__tests__",
+                "__mocks__",
+                "\\.d\\.ts$",
+                "\\/node_modules\\/",
+                "\\.git"
+            ]
+        }
     },
     "plugins": [ "@specify/plugin-cli" ]
 }


### PR DESCRIPTION
This change implements the `TestCommandWatcher` class which allows users to run the command `specify --watch` and persist the process so that any newly detected file changes are automatically executed.

The watcher is as smart as it can be, I think. It will only run executions after previous executions have been completed; it will queue up to 1 additional execution that will trigger once the current execution has completed.

If the `specify.config.json` file is changed, the watcher will notify the user the watcher must be restarted:
<img width="822" height="194" alt="image" src="https://github.com/user-attachments/assets/86b993ae-0b0c-4287-bdff-8ee30d421150" />

A debug mode provides additional output in cases where the user may need to troubleshoot why something happened or where things are being saved:
<img width="860" height="215" alt="image" src="https://github.com/user-attachments/assets/fe0ecba9-9180-43e8-a2e2-b99b4fc068d5" />

The config has been extended to use a `watch.config.ts` file which can be overridden via `specify.config.json` by adding a `watch` property to the JSON configuration there:

```json
{
    "debug":  false,
    "paths":  ["./"],
    "ignore": [
        "\\.test\\.ts$",
        "\\.spec\\.ts$",
        "__tests__",
        "__mocks__",
        "\\.d\\.ts$",
        "\\/node_modules\\/",
        "\\.git",
    ],
    "events": ["add", "change", "unlink"],
}
```