### PR TITLE
[#84] Allow String Verification in Command Output

### DIFF
--- a/features/test/basic.feature
+++ b/features/test/basic.feature
@@ -55,7 +55,7 @@ Feature: Basic Test Execution
             When a user runs the command "npx specify test ./assets/gherkin/no-features/test.md"
             Then the command should return an "error" exit code
             And the console output should be a "no test cases error"
-        
+
         @skip
         Scenario: User-specified path contains no scenarios
             When a user runs the command "npx specify test ./assets/gherkin/empty.feature"

--- a/features/test/basic.feature
+++ b/features/test/basic.feature
@@ -13,16 +13,22 @@ Feature: Basic Test Execution
         Scenario: All tests pass
             When a user runs the command "npx specify test ./assets/gherkin/binary/passing.feature"
             Then the command should return a "success" exit code
-            And the console output should be a "passing test result"
+            And the last command's terminal output should be a "passing test result"
 
         Scenario: All tests fail
             When a user runs the command "npx specify test ./assets/gherkin/binary/failing.feature"
             Then the command should return a "failure" exit code
-            And the console output should be a "failing test result"
+            And the last command's terminal output should be a "failing test result"
 
         Scenario: Mixed pass/fail tests
             When a user runs the command "npx specify test ./assets/gherkin/binary/"
             Then the command should return a "failure" exit code
+
+    Rule: The run should allow verification of string values in terminal output
+
+        Scenario: Verify string in terminal output
+            When a user runs the command "echo foobar"
+            Then the last command's terminal output should be "foobar"
 
     Rule: The run should error if there are invalid features
 
@@ -42,25 +48,25 @@ Feature: Basic Test Execution
         Scenario: User-specified path does not exist
             When a user runs the command "npx specify test ./nonexistent/path/"
             Then the command should return an "error" exit code
-            And the console output should be a "path not found error"
+            And the last command's terminal output should be a "path not found error"
 
         @skip
         Scenario: User-specified path is empty
             When a user runs the command "npx specify test ./assets/gherkin/empty/"
             Then the command should return an "error" exit code
-            And the console output should be a "no test cases error"
+            And the last command's terminal output should be a "no test cases error"
 
         @skip
         Scenario: User-specified path contains no features
             When a user runs the command "npx specify test ./assets/gherkin/no-features/test.md"
             Then the command should return an "error" exit code
-            And the console output should be a "no test cases error"
+            And the last command's terminal output should be a "no test cases error"
 
         @skip
         Scenario: User-specified path contains no scenarios
             When a user runs the command "npx specify test ./assets/gherkin/empty.feature"
             Then the command should return a "failure" exit code
-            And the console output should be a "no test cases error"
+            And the last command's terminal output should be a "no test cases error"
 
     Rule: Execution without a subcommand should default to testing
 
@@ -81,7 +87,7 @@ Feature: Basic Test Execution
         Scenario: Unmatched tags cause an error
             When a user runs the command "npx specify test --tags '@nevermatch'"
             Then the command should return an "error" exit code
-            And the console output should be a "no test cases error"
+            And the last command's terminal output should be a "no test cases error"
 
     Rule: Invalid commands display usage help
 
@@ -89,16 +95,16 @@ Feature: Basic Test Execution
         Scenario: Unsupported subcommand
             When a user runs the command "npx specify bad-subcommand"
             Then the command should return a "failure" exit code
-            And the console output should be a "invalid command message"
+            And the last command's terminal output should be a "invalid command message"
 
         @skip
         Scenario: Unsupported option
             When a user runs the command "npx specify --bad-option"
             Then the command should return a "failure" exit code
-            And the console output should be a "invalid command message"
+            And the last command's terminal output should be a "invalid command message"
 
         @skip
         Scenario: Mix of supported and unsupported options
             When a user runs the command "npx specify --tag '@pass' --bad-option"
             Then the command should return a "failure" exit code
-            And the console output should be a "invalid command message"
+            And the last command's terminal output should be a "invalid command message"

--- a/modules/@specify/plugin-cli/src/cucumber/step_definitions/shell.ts
+++ b/modules/@specify/plugin-cli/src/cucumber/step_definitions/shell.ts
@@ -23,7 +23,9 @@ When("a/the user waits for the last command to return", { "timeout": 60000 }, wa
 
 Then("the command should return a/an/the {ref:exitCode} exit code", verifyExitCode);
 
-Then("the console output should be a/an/the {ref:consoleOutput}", verifyOutput);
+Then("the last command's terminal output should be {string}", verifyOutput);
+
+Then("the last command's terminal output should be a/an/the {ref:consoleOutput}", verifyOutput);
 
 /**
  * Execute the given command via the CLI asynchronously and move on without
@@ -76,7 +78,11 @@ function startDefaultShell(): void {
  * @throws {@link AssertionError}
  * If the matcher regexp wasnt found
  */
-function verifyOutput(consoleOutput: RegExp): void {
+function verifyOutput(consoleOutput: RegExp | string): void {
+    if (typeof consoleOutput === "string") {
+        consoleOutput = new RegExp(consoleOutput, "u");
+    }
+
     assert.ok(
         consoleOutput.test(this.cli.manager.output),
         new AssertionError({

--- a/modules/@specify/plugin-cli/src/cucumber/step_definitions/shell.ts
+++ b/modules/@specify/plugin-cli/src/cucumber/step_definitions/shell.ts
@@ -23,9 +23,12 @@ When("a/the user waits for the last command to return", { "timeout": 60000 }, wa
 
 Then("the command should return a/an/the {ref:exitCode} exit code", verifyExitCode);
 
-Then("the last command's terminal output should be {string}", verifyOutput);
+Then("the last command's terminal output should be/include {string}", verifyOutput);
 
-Then("the last command's terminal output should be a/an/the {ref:consoleOutput}", verifyOutput);
+Then(
+    "the last command's terminal output should be/include a/an/the {ref:consoleOutput}",
+    verifyOutput,
+);
 
 /**
  * Execute the given command via the CLI asynchronously and move on without


### PR DESCRIPTION
Updated the wording of the step definition to verify console output to:

```gherkin
            And the last command's terminal output should be a "ref"
```

And updated the step to support raw string input:

```gherkin
            And the last command's terminal output should be "raw string value"
```