### PR TITLE
Add CLAUDE.md for Claude Code guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,3 +73,19 @@ specify test [paths] [options]
   → CucumberManager dispatches hooks/steps
   → SpecifyWorld (with QuickRef) created per scenario
 ```
+
+## Contributing
+
+**Issue tracker:** https://github.com/specify-bdd/specify-core/issues
+
+**Commit messages:**
+```
+[#<github-issue-id>] <explanation of why the change was needed>
+```
+Focus on *why*, not *what* — the diff covers what changed. Omit the ticket prefix only when there is genuinely no associated issue.
+
+**Pull requests:**
+- Always open a PR; never push directly to `main` or `develop`
+- Target `develop` by default. If the ticket's GitHub milestone matches a `rel/*` branch name, target that branch instead
+- Assign `specify-bdd/devs` as reviewer
+- PR description should include `Resolves #<issue>.` where applicable

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,75 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Setup (first time)
+pnpm dev:install        # install deps + generate types + build all packages
+
+# Build
+pnpm build              # build all workspace packages
+
+# Tests
+pnpm test               # unit tests + BDD integration tests
+pnpm test:unit          # Vitest unit tests only
+pnpm test:unit:watch    # unit tests in watch mode
+vitest run --reporter=verbose <path>   # single unit test file
+
+# Run specific BDD feature
+pnpm specify test ./features/test/basic.feature
+pnpm specify test --tags '@tagname'
+
+# Lint & type-check
+pnpm lint               # check formatting and lint errors
+pnpm lint:fix           # auto-fix formatting and lint issues
+pnpm type-check         # TypeScript type checking (tsc)
+
+# Development
+pnpm dev:watch          # watch mode - auto-rebuild on file changes
+```
+
+## Architecture
+
+PNPM monorepo with four workspace packages under `modules/@specify-bdd/`:
+
+### Packages
+
+- **`specify`** – Core BDD framework CLI. Entry point: `src/exec.ts` (CLI) and `src/index.ts` (public API). Wraps Cucumber.js with enhanced step pattern parsing, plugin loading, and test lifecycle management.
+- **`plugin-cli`** – Optional plugin providing Cucumber step definitions for shell/file system interaction. Used in feature tests that exercise CLI behavior.
+- **`quick-ref`** – Utility for storing/retrieving test data by dot-notation address (`"foo.bar"`) with template string interpolation (`${foo.bar}`). Integrated into `SpecifyWorld`.
+- **`eslint-plugin`** – Private package with custom alignment ESLint rules used across the codebase.
+
+### Core Classes (in `specify/src/lib/`)
+
+- **`CucumberManager`** – Singleton that wraps Cucumber step/hook registration. Parses optional notation `[...]` in Gherkin patterns, supporting alternates (`[create/update]`) and subject substitution.
+- **`SpecifyWorld`** – Custom Cucumber World (per-scenario instance) with an integrated `QuickRef` instance for parameter storage.
+- **`TestCommand`** / **`TestCommandWatcher`** – Orchestrate test execution; watcher triggers reruns on file changes.
+- **`CucumberAPI`** – Thin interface to Cucumber's programmatic runner.
+
+### Configuration System
+
+Config is modular, loaded from `src/config/` submodules (paths, cucumber, content, plugins, debug, watch) and merged via deepmerge. User overrides come from `./specify.config.json` in the process working directory. The merged config is managed by `src/config/all.ts`.
+
+### Test Structure
+
+- `modules/@specify-bdd/specify/src/lib/tests/` – Vitest unit tests for core classes
+- `features/test/` – Gherkin feature files + step definitions that test Specify itself (self-hosted BDD tests)
+- `test/gherkin/` – Fixture feature files used as test inputs (passing/failing scenarios for testing retry, parallel, rerun, etc.)
+
+### Plugin System
+
+External plugins export a `{ cucumber: {...} }` object. Paths are configured in `specify.config.json` under `plugins`. The framework merges plugin cucumber configs (steps, hooks, world) before execution.
+
+### Data Flow
+
+```
+specify test [paths] [options]
+  → exec.ts: parse args + load config
+  → load plugins (merge cucumber config)
+  → TestCommand.execute()
+  → CucumberAPI.run()
+  → CucumberManager dispatches hooks/steps
+  → SpecifyWorld (with QuickRef) created per scenario
+```

--- a/scripts/bot-auth.sh
+++ b/scripts/bot-auth.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# bot-auth.sh — Authenticate gh CLI using a GitHub App installation token.
+#
+# Configuration (environment variables take precedence over config file):
+#   GITHUB_APP_ID               — GitHub App's App ID
+#   GITHUB_APP_INSTALLATION_ID  — Installation ID (GitHub App settings > Installations)
+#   GITHUB_APP_PRIVATE_KEY_PATH — Path to the App's private key (.pem file)
+#
+# Config file (optional fallback): ~/.config/specify-bdd-bot/config
+#   GITHUB_APP_ID=12345
+#   GITHUB_APP_INSTALLATION_ID=67890
+#   GITHUB_APP_PRIVATE_KEY_PATH=/path/to/private-key.pem
+#
+# Set DEBUG_MODE=1 to print verbose output.
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+# ---------------------------------------------------------------------------
+# Load config file if present (env vars take precedence)
+# ---------------------------------------------------------------------------
+CONFIG_FILE="${HOME}/.config/specify-bdd-bot/config"
+if [[ -f "$CONFIG_FILE" ]]; then
+  debug "Loading config from ${CONFIG_FILE}"
+  # shellcheck source=/dev/null
+  source "$CONFIG_FILE"
+else
+  debug "No config file found at ${CONFIG_FILE}; relying on environment variables"
+fi
+
+# ---------------------------------------------------------------------------
+# Validate required config
+# ---------------------------------------------------------------------------
+[[ -n "${GITHUB_APP_ID:-}" ]]               || fail "GITHUB_APP_ID is not set. Configure it in ${CONFIG_FILE} or the environment."
+[[ -n "${GITHUB_APP_INSTALLATION_ID:-}" ]]  || fail "GITHUB_APP_INSTALLATION_ID is not set. Configure it in ${CONFIG_FILE} or the environment."
+[[ -n "${GITHUB_APP_PRIVATE_KEY_PATH:-}" ]] || fail "GITHUB_APP_PRIVATE_KEY_PATH is not set. Configure it in ${CONFIG_FILE} or the environment."
+[[ -f "$GITHUB_APP_PRIVATE_KEY_PATH" ]]     || fail "Private key not found at: ${GITHUB_APP_PRIVATE_KEY_PATH}"
+
+debug "App ID: ${GITHUB_APP_ID}"
+debug "Installation ID: ${GITHUB_APP_INSTALLATION_ID}"
+debug "Private key: ${GITHUB_APP_PRIVATE_KEY_PATH}"
+
+# ---------------------------------------------------------------------------
+# Helper: base64url encode (no padding)
+# ---------------------------------------------------------------------------
+b64url() {
+  openssl base64 -e -A | tr '+/' '-_' | tr -d '='
+}
+
+# ---------------------------------------------------------------------------
+# Build JWT
+# ---------------------------------------------------------------------------
+info "Building JWT..."
+
+NOW=$(date +%s)
+IAT=$((NOW - 60))   # issued slightly in the past to account for clock skew
+EXP=$((NOW + 600))  # 10 minutes (GitHub maximum)
+
+HEADER=$(printf '{"alg":"RS256","typ":"JWT"}' | b64url) \
+  || fail "Failed to base64url-encode JWT header."
+
+PAYLOAD=$(printf '{"iat":%d,"exp":%d,"iss":"%s"}' "$IAT" "$EXP" "$GITHUB_APP_ID" | b64url) \
+  || fail "Failed to base64url-encode JWT payload."
+
+SIGNATURE=$(printf '%s.%s' "$HEADER" "$PAYLOAD" \
+  | openssl dgst -sha256 -sign "$GITHUB_APP_PRIVATE_KEY_PATH" \
+  | b64url) \
+  || fail "Failed to sign JWT. Check that the private key is valid and readable."
+
+JWT="${HEADER}.${PAYLOAD}.${SIGNATURE}"
+debug "JWT: ${JWT}"
+
+# ---------------------------------------------------------------------------
+# Exchange JWT for an installation access token
+# ---------------------------------------------------------------------------
+info "Requesting installation access token..."
+
+RESPONSE=$(curl --silent --show-error --fail \
+  -X POST \
+  -H "Authorization: Bearer ${JWT}" \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "https://api.github.com/app/installations/${GITHUB_APP_INSTALLATION_ID}/access_tokens") \
+  || fail "GitHub API request failed. Check your App ID, Installation ID, and that the app is installed on the repo."
+
+debug "GitHub API response: ${RESPONSE}"
+
+TOKEN=$(printf '%s' "$RESPONSE" | grep -o '"token": *"[^"]*"' | cut -d'"' -f4) \
+  || fail "Failed to extract token from API response."
+EXPIRES_AT=$(printf '%s' "$RESPONSE" | grep -o '"expires_at": *"[^"]*"' | cut -d'"' -f4)
+
+[[ -n "$TOKEN" ]] || fail "Token was empty in API response. Full response: ${RESPONSE}"
+
+# ---------------------------------------------------------------------------
+# Authenticate gh
+# ---------------------------------------------------------------------------
+info "Authenticating gh CLI..."
+
+echo "$TOKEN" | gh auth login --with-token \
+  || fail "gh auth login failed. Ensure gh is installed and the token is valid."
+
+end "gh authenticated successfully. Token expires at: ${EXPIRES_AT}"


### PR DESCRIPTION
Adds a `CLAUDE.md` file to help Claude Code instances quickly understand the development workflow and codebase architecture without needing to re-derive it from scratch each session.

Covers build/test/lint commands, high-level architecture of the monorepo packages and core classes, and contributing conventions (commit format, PR workflow, issue tracker).