### PR TITLE
intstr supremacy

### DIFF
--- a/features/plugin-cli/steps/shell.feature
+++ b/features/plugin-cli/steps/shell.feature
@@ -16,7 +16,7 @@ Feature: Shell Step Definitions
         Scenario: Create multiple shells
             Given a CLI shell
             When the user starts another CLI shell
-            Then there should be "2" active CLI shells
+            Then there should be 2 active CLI shells
 
         Scenario: Destroy the active shell
             Given a CLI shell

--- a/features/plugin-cli/steps/shell.feature
+++ b/features/plugin-cli/steps/shell.feature
@@ -16,7 +16,7 @@ Feature: Shell Step Definitions
         Scenario: Create multiple shells
             Given a CLI shell
             When the user starts another CLI shell
-            Then there should be 2 active CLI shells
+            Then there should be "2" active CLI shells
 
         Scenario: Destroy the active shell
             Given a CLI shell

--- a/modules/@specify-bdd/plugin-cli/src/cucumber/step_definitions/shell.ts
+++ b/modules/@specify-bdd/plugin-cli/src/cucumber/step_definitions/shell.ts
@@ -13,18 +13,18 @@ import { ShellSession             } from "@/lib/ShellSession";
 
 import type { SpawnOptions } from "node:child_process";
 
-defineStep("When [I kill/the user kills] CLI shell {int}", killCLIShellByIndex);
+defineStep("When [I kill/the user kills] CLI shell {flexInt}", killCLIShellByIndex);
 defineStep("When [I kill/the user kills] the CLI shell", killCLIShell);
 defineStep("When [I kill/the user kills] the CLI shell named {string}", killCLIShellByName);
 defineStep("When [I send/the user sends] a {cliSignal} signal to the last command", sendKillSignal);
 defineStep("When [I start/the user starts] a/an/the (async )command/process {refstr}", execCommand);
 defineStep("When [I switch/the user switches] CLI shells", switchToNextShell);
-defineStep("When [I switch/the user switches] to CLI shell {int}", switchShellByIndex);
+defineStep("When [I switch/the user switches] to CLI shell {flexInt}", switchShellByIndex);
 defineStep("When [I switch/the user switches] to the CLI shell named {string}", switchShellByName);
 defineStep("When [I wait/the user waits] for terminal output", waitForAnyOutput, {
     "timeout": 60000,
 });
-defineStep("Then there should be {int} active CLI shell(s)", verifyShellCount);
+defineStep("Then there should be {flexInt} active CLI shell(s)", verifyShellCount);
 
 defineStep(
     ["Given a/another CLI shell", "When [I start/the user starts] a/another CLI shell"],
@@ -78,9 +78,9 @@ defineStep(
 
 defineStep(
     [
-        "Then the last command's exit code/status should be {int}",
+        "Then the last command's exit code/status should be {flexInt}",
         "Then the last command's exit code/status should be {ref}",
-        "Then the last command's exit code/status should be a/an {int}",
+        "Then the last command's exit code/status should be a/an {flexInt}",
         "Then the last command's exit code/status should be a/an {ref}",
     ],
     verifyExitCode,

--- a/modules/@specify-bdd/plugin-cli/src/cucumber/step_definitions/shell.ts
+++ b/modules/@specify-bdd/plugin-cli/src/cucumber/step_definitions/shell.ts
@@ -13,18 +13,36 @@ import { ShellSession             } from "@/lib/ShellSession";
 
 import type { SpawnOptions } from "node:child_process";
 
-defineStep("When [I kill/the user kills] CLI shell {flexInt}", killCLIShellByIndex);
+defineStep(
+    [
+        "When [I kill/the user kills] CLI shell {int}",
+        "When [I kill/the user kills] CLI shell {intstr}",
+    ],
+    killCLIShellByIndex,
+);
 defineStep("When [I kill/the user kills] the CLI shell", killCLIShell);
 defineStep("When [I kill/the user kills] the CLI shell named {string}", killCLIShellByName);
 defineStep("When [I send/the user sends] a {cliSignal} signal to the last command", sendKillSignal);
 defineStep("When [I start/the user starts] a/an/the (async )command/process {refstr}", execCommand);
 defineStep("When [I switch/the user switches] CLI shells", switchToNextShell);
-defineStep("When [I switch/the user switches] to CLI shell {flexInt}", switchShellByIndex);
+defineStep(
+    [
+        "When [I switch/the user switches] to CLI shell {int}",
+        "When [I switch/the user switches] to CLI shell {intstr}",
+    ],
+    switchShellByIndex,
+);
 defineStep("When [I switch/the user switches] to the CLI shell named {string}", switchShellByName);
 defineStep("When [I wait/the user waits] for terminal output", waitForAnyOutput, {
     "timeout": 60000,
 });
-defineStep("Then there should be {flexInt} active CLI shell(s)", verifyShellCount);
+defineStep(
+    [
+        "Then there should be {int} active CLI shell(s)",
+        "Then there should be {intstr} active CLI shell(s)",
+    ],
+    verifyShellCount,
+);
 
 defineStep(
     ["Given a/another CLI shell", "When [I start/the user starts] a/another CLI shell"],
@@ -78,9 +96,11 @@ defineStep(
 
 defineStep(
     [
-        "Then the last command's exit code/status should be {flexInt}",
+        "Then the last command's exit code/status should be {int}",
+        "Then the last command's exit code/status should be {intstr}",
         "Then the last command's exit code/status should be {ref}",
-        "Then the last command's exit code/status should be a/an {flexInt}",
+        "Then the last command's exit code/status should be a/an {int}",
+        "Then the last command's exit code/status should be a/an {intstr}",
         "Then the last command's exit code/status should be a/an {ref}",
     ],
     verifyExitCode,

--- a/modules/@specify-bdd/plugin-cli/src/cucumber/support/param_types.ts
+++ b/modules/@specify-bdd/plugin-cli/src/cucumber/support/param_types.ts
@@ -9,8 +9,8 @@ import { defineParamType        } from "@specify-bdd/specify";
 import assert, { AssertionError } from "node:assert/strict";
 import { constants              } from "node:os";
 
-// matches "1", "-2", '3', but not '4". Auto-strips quotes
-const quotedInt = /'(-?\d+)'|"(-?\d+)"/;
+// matches "1", "-2", '3', but not '4". Quotes stripped in transformer.
+const quotedInt = /'-?\d+'|"-?\d+"/;
 
 const quotedString = /"(?:\\.|[^\\"])*"|'(?:\\.|[^\\'])*'/;
 
@@ -33,8 +33,8 @@ defineParamType({
 defineParamType({
     "name":   "intstr",
     "regexp": quotedInt,
-    transformer(single: string, double: string): number {
-        return parseInt(single ?? double, 10);
+    transformer(input: string): number {
+        return parseInt(input.slice(1, -1), 10);
     },
     "useForSnippets": false,
 });

--- a/modules/@specify-bdd/plugin-cli/src/cucumber/support/param_types.ts
+++ b/modules/@specify-bdd/plugin-cli/src/cucumber/support/param_types.ts
@@ -9,8 +9,10 @@ import { defineParamType        } from "@specify-bdd/specify";
 import assert, { AssertionError } from "node:assert/strict";
 import { constants              } from "node:os";
 
+// matches "1", "-2", '3', but not '4". Auto-strips quotes
+const quotedInt = /'(-?\d+)'|"(-?\d+)"/;
+
 const quotedString = /"(?:\\.|[^\\"])*"|'(?:\\.|[^\\'])*'/;
-const flexInt      = new RegExp(`-?\\d+|${quotedString.source}`);
 
 defineParamType({
     "name":   "cliSignal",
@@ -29,21 +31,10 @@ defineParamType({
 });
 
 defineParamType({
-    "name":   "flexInt",
-    "regexp": flexInt,
-    transformer(input: string): number {
-        if (input.startsWith('"') || input.startsWith("'")) {
-            input = input.slice(1, -1);
-        }
-
-        const num = Number(input);
-
-        assert.ok(
-            Number.isInteger(num),
-            new AssertionError({ "message": `Expected a valid integer but received "${input}"` }),
-        );
-
-        return num;
+    "name":   "intstr",
+    "regexp": quotedInt,
+    transformer(single: string, double: string): number {
+        return parseInt(single ?? double, 10);
     },
     "useForSnippets": false,
 });

--- a/modules/@specify-bdd/plugin-cli/src/cucumber/support/param_types.ts
+++ b/modules/@specify-bdd/plugin-cli/src/cucumber/support/param_types.ts
@@ -9,6 +9,7 @@ import { defineParamType        } from "@specify-bdd/specify";
 import assert, { AssertionError } from "node:assert/strict";
 import { constants              } from "node:os";
 
+const flexInt      = /-?\d+|"(?:\\.|[^\\"])*"|'(?:\\.|[^\\'])*'/; // integer or quoted string
 const quotedString = /"(?:\\.|[^\\"])*"|'(?:\\.|[^\\'])*'/;
 
 defineParamType({
@@ -23,6 +24,26 @@ defineParamType({
         );
 
         return parsedInput;
+    },
+    "useForSnippets": false,
+});
+
+defineParamType({
+    "name":   "flexInt",
+    "regexp": flexInt,
+    transformer(input: string): number {
+        if (input.startsWith('"') || input.startsWith("'")) {
+            input = input.slice(1, -1);
+        }
+
+        const result = parseInt(input, 10);
+
+        assert.ok(
+            !isNaN(result),
+            new AssertionError({ "message": `Expected a valid integer but received "${input}"` }),
+        );
+        
+        return result;
     },
     "useForSnippets": false,
 });

--- a/modules/@specify-bdd/plugin-cli/src/cucumber/support/param_types.ts
+++ b/modules/@specify-bdd/plugin-cli/src/cucumber/support/param_types.ts
@@ -9,8 +9,8 @@ import { defineParamType        } from "@specify-bdd/specify";
 import assert, { AssertionError } from "node:assert/strict";
 import { constants              } from "node:os";
 
-const flexInt      = /-?\d+|"(?:\\.|[^\\"])*"|'(?:\\.|[^\\'])*'/; // integer or quoted string
-const quotedString = /"(?:\\.|[^\\"])*"|'(?:\\.|[^\\'])*'/;
+const quotedString = /"(?:\\.|[^\\"])*"|'(?:\\.|[^\\'])*'/;                                                                                                              
+const flexInt      = new RegExp(`-?\\d+|${quotedString.source}`); 
 
 defineParamType({
     "name":   "cliSignal",
@@ -35,15 +35,15 @@ defineParamType({
         if (input.startsWith('"') || input.startsWith("'")) {
             input = input.slice(1, -1);
         }
-
-        const result = parseInt(input, 10);
+        
+        const num = Number(input);
 
         assert.ok(
-            !isNaN(result),
+            Number.isInteger(num),
             new AssertionError({ "message": `Expected a valid integer but received "${input}"` }),
         );
-        
-        return result;
+
+        return num;
     },
     "useForSnippets": false,
 });

--- a/modules/@specify-bdd/plugin-cli/src/cucumber/support/param_types.ts
+++ b/modules/@specify-bdd/plugin-cli/src/cucumber/support/param_types.ts
@@ -9,8 +9,8 @@ import { defineParamType        } from "@specify-bdd/specify";
 import assert, { AssertionError } from "node:assert/strict";
 import { constants              } from "node:os";
 
-const quotedString = /"(?:\\.|[^\\"])*"|'(?:\\.|[^\\'])*'/;                                                                                                              
-const flexInt      = new RegExp(`-?\\d+|${quotedString.source}`); 
+const quotedString = /"(?:\\.|[^\\"])*"|'(?:\\.|[^\\'])*'/;
+const flexInt      = new RegExp(`-?\\d+|${quotedString.source}`);
 
 defineParamType({
     "name":   "cliSignal",
@@ -35,7 +35,7 @@ defineParamType({
         if (input.startsWith('"') || input.startsWith("'")) {
             input = input.slice(1, -1);
         }
-        
+
         const num = Number(input);
 
         assert.ok(

--- a/modules/@specify-bdd/specify/src/lib/CucumberManager.ts
+++ b/modules/@specify-bdd/specify/src/lib/CucumberManager.ts
@@ -34,7 +34,7 @@ export interface ParamTypeOptions {
     name: string;
     preferForRegexpMatch?: boolean;
     regexp: RegExp;
-    transformer?: (arg: string) => any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    transformer?: (...args: string[]) => any; // eslint-disable-line @typescript-eslint/no-explicit-any
     useForSnippets?: boolean;
 }
 


### PR DESCRIPTION
These definitions use the same handler;
```
Then the last command's exit code should be a 1
Then the last command's exit code should be a "1"
```
Accomplished via our brand new param type, ~~`flexInt`~~ `intstr`
```
"Then the last command's exit code/status should be {int}"
"Then the last command's exit code/status should be {intstr}"
```