### PR TITLE
Dependency notations

### DIFF
--- a/modules/@specify-bdd/plugin-browser/package.json
+++ b/modules/@specify-bdd/plugin-browser/package.json
@@ -19,7 +19,7 @@
     "test:unit": "vitest run"
   },
   "dependencies": {
-    "@specify-bdd/specify": "workspace:*",
+    "@specify-bdd/specify": "workspace:^",
     "webdriverio": "^9"
   },
   "devDependencies": {

--- a/modules/@specify-bdd/plugin-cli/package.json
+++ b/modules/@specify-bdd/plugin-cli/package.json
@@ -21,7 +21,7 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "@specify-bdd/specify": "workspace:*",
+        "@specify-bdd/specify": "workspace:^",
         "ps-list": "^9.0.0",
         "tree-kill": "^1.2.2",
         "validate-npm-package-name": "^6.0.2"

--- a/modules/@specify-bdd/specify/package.json
+++ b/modules/@specify-bdd/specify/package.json
@@ -26,7 +26,7 @@
     },
     "dependencies": {
         "@cucumber/cucumber": "^12.7.0",
-        "@specify-bdd/quick-ref": "workspace:*",
+        "@specify-bdd/quick-ref": "workspace:^",
         "chalk": "^5.6.2",
         "chokidar": "^4.0.3",
         "commander": "^14.0.2",

--- a/package.json
+++ b/package.json
@@ -27,16 +27,16 @@
         "type-check:watch": "rimraf **/dist/tsconfig.tsbuildinfo && tsc -b --noEmit --watch"
     },
     "dependencies": {
-        "@specify-bdd/plugin-browser": "workspace:*",
-        "@specify-bdd/plugin-cli": "workspace:*",
-        "@specify-bdd/quick-ref": "workspace:*",
-        "@specify-bdd/specify": "workspace:*"
+        "@specify-bdd/plugin-browser": "workspace:^",
+        "@specify-bdd/plugin-cli": "workspace:^",
+        "@specify-bdd/quick-ref": "workspace:^",
+        "@specify-bdd/specify": "workspace:^"
     },
     "devDependencies": {
         "@eslint/js": "^9.39.2",
         "@microsoft/tsdoc": "^0.15.1",
         "@microsoft/tsdoc-config": "^0.17.1",
-        "@specify-bdd/eslint-plugin": "workspace:*",
+        "@specify-bdd/eslint-plugin": "workspace:^",
         "@stylistic/eslint-plugin-js": "^4.4.1",
         "@types/lodash": "^4.17.23",
         "@types/node": "^22.19.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,16 +31,16 @@ importers:
   .:
     dependencies:
       '@specify-bdd/plugin-browser':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:modules/@specify-bdd/plugin-browser
       '@specify-bdd/plugin-cli':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:modules/@specify-bdd/plugin-cli
       '@specify-bdd/quick-ref':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:modules/@specify-bdd/quick-ref
       '@specify-bdd/specify':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:modules/@specify-bdd/specify
     devDependencies:
       '@eslint/js':
@@ -53,7 +53,7 @@ importers:
         specifier: ^0.17.1
         version: 0.17.1
       '@specify-bdd/eslint-plugin':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:modules/@specify-bdd/eslint-plugin
       '@stylistic/eslint-plugin-js':
         specifier: ^4.4.1
@@ -156,7 +156,7 @@ importers:
   modules/@specify-bdd/plugin-browser:
     dependencies:
       '@specify-bdd/specify':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../specify
       webdriverio:
         specifier: ^9
@@ -175,7 +175,7 @@ importers:
   modules/@specify-bdd/plugin-cli:
     dependencies:
       '@specify-bdd/specify':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../specify
       ps-list:
         specifier: ^9.0.0
@@ -219,7 +219,7 @@ importers:
         specifier: ^12.7.0
         version: 12.7.0
       '@specify-bdd/quick-ref':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../quick-ref
       chalk:
         specifier: ^5.6.2


### PR DESCRIPTION
Updated package.json files to replace `workspace:*` notations with `workspace:^`, which should achieve the correct dependency version outputs for Specify packages during publication.

This doesn't fix the major problem we currently have in our production packages, which is that the `workspace:*` notation is being published in the live package even though PNPM is supposed to convert it.  I think the cause of that problem is user error, however; I had to manually publish some packages after encountering errors due to NPM trusted publishing misconfiguration, and I think I used `npm publish` instead of `pnpm publish`.  Thus, the problem came from me not giving PNPM the chance to do its job.

To fix that, we need a new version of the code to publish, and this fix will give us one.  It means the difference between publishing package.json files with `"@specify-bdd/specify": "0.5.2"` and `"@specify-bdd/specify": "^0.5.2"`.  The latter is what we want, ultimately.  Once this is merged, we can release it and confirm that the automated process (now unkinked, I hope) can do everything correctly and publish well-formed packages with good dependency notation.